### PR TITLE
Use base-compat to reduce CPP cruft

### DIFF
--- a/hermit.cabal
+++ b/hermit.cabal
@@ -130,10 +130,11 @@ extra-source-files:
     examples/new_reverse/Reverse.hec
 
 Library
-  ghc-options: -Wall -fno-warn-orphans
+  ghc-options: -Wall
   Build-Depends: base                >= 4 && < 5,
                  ansi-terminal       >= 0.5.5,
                  array,
+                 base-compat         >= 0.8.1,
                  containers          >= 0.5.0.0,
                  data-default-class  >= 0.0.1,
                  directory           >= 1.2.0.0,
@@ -254,7 +255,7 @@ Executable hermit
     default-language: Haskell2010
     Main-Is: Main.hs
     Hs-Source-Dirs: driver
-    Ghc-Options:
+    Ghc-Options: -Wall
 
 source-repository head
     type:     git

--- a/src/HERMIT/Context.hs
+++ b/src/HERMIT/Context.hs
@@ -1,8 +1,9 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module HERMIT.Context
     ( -- * HERMIT Contexts
@@ -49,13 +50,10 @@ module HERMIT.Context
     , HasEmptyContext(..)
     ) where
 
-import Prelude hiding (lookup)
+import Prelude.Compat hiding (lookup)
 
 import Control.Monad (liftM)
 
-#if __GLASGOW_HASKELL__ < 710
-import Data.Monoid (mempty)
-#endif
 import Data.Map hiding (map, foldr, filter)
 
 import Language.KURE

--- a/src/HERMIT/Core.hs
+++ b/src/HERMIT/Core.hs
@@ -1,4 +1,6 @@
-{-# LANGUAGE CPP, LambdaCase #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE LambdaCase #-}
+
 module HERMIT.Core
     ( -- * Generic Data Type
       CoreProg(..)

--- a/src/HERMIT/Dictionary/AlphaConversion.hs
+++ b/src/HERMIT/Dictionary/AlphaConversion.hs
@@ -1,4 +1,6 @@
-{-# LANGUAGE FlexibleContexts, ScopedTypeVariables #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
 module HERMIT.Dictionary.AlphaConversion
     ( -- * Alpha-Renaming and Shadowing
       externals

--- a/src/HERMIT/Dictionary/Common.hs
+++ b/src/HERMIT/Dictionary/Common.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 -- | Note: this module should NOT export externals. It is for common
 --   transformations needed by the other primitive modules.
@@ -46,10 +46,7 @@ module HERMIT.Dictionary.Common
 
 where
 
-import Data.List
-#if __GLASGOW_HASKELL__ < 710
-import Data.Monoid
-#endif
+import Data.List (nub)
 
 import Control.Arrow
 import Control.Monad.IO.Class
@@ -60,6 +57,8 @@ import HERMIT.GHC
 import HERMIT.Kure
 import HERMIT.Monad
 import HERMIT.Name
+
+import Prelude.Compat
 
 ------------------------------------------------------------------------------
 

--- a/src/HERMIT/Dictionary/FixPoint.hs
+++ b/src/HERMIT/Dictionary/FixPoint.hs
@@ -1,4 +1,6 @@
-{-# LANGUAGE FlexibleContexts, ScopedTypeVariables #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module HERMIT.Dictionary.FixPoint
     ( -- * Operations on the Fixed Point Operator (fix)
@@ -23,7 +25,7 @@ import Data.String (fromString)
 import HERMIT.Context
 import HERMIT.Core
 import HERMIT.Monad
-import HERMIT.Kure
+import HERMIT.Kure hiding ((<$>))
 import HERMIT.External
 import HERMIT.GHC
 import HERMIT.Name
@@ -36,6 +38,8 @@ import HERMIT.Dictionary.Kure
 import HERMIT.Dictionary.Reasoning
 import HERMIT.Dictionary.Undefined
 import HERMIT.Dictionary.Unfold
+
+import Prelude.Compat
 
 --------------------------------------------------------------------------------------------------
 

--- a/src/HERMIT/Dictionary/Fold.hs
+++ b/src/HERMIT/Dictionary/Fold.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeSynonymInstances #-}
@@ -37,7 +38,7 @@ import HERMIT.Core
 import HERMIT.Context
 import HERMIT.External
 import HERMIT.GHC
-import HERMIT.Kure
+import HERMIT.Kure hiding ((<$>))
 import HERMIT.Lemma
 import HERMIT.Monad
 import HERMIT.Name
@@ -49,7 +50,7 @@ import HERMIT.Dictionary.Inline hiding (externals)
 import HERMIT.PrettyPrinter.Common
 import qualified Text.PrettyPrint.MarkedHughesPJ as PP
 
-import Prelude hiding (exp)
+import Prelude.Compat hiding (exp)
 
 ------------------------------------------------------------------------
 

--- a/src/HERMIT/Dictionary/Fold.hs
+++ b/src/HERMIT/Dictionary/Fold.hs
@@ -25,7 +25,7 @@ module HERMIT.Dictionary.Fold
     ) where
 
 import Control.Arrow
-import Control.Monad
+import Control.Monad (liftM)
 import Control.Monad.IO.Class
 
 import Data.List (delete, (\\), intersect)

--- a/src/HERMIT/Dictionary/Function.hs
+++ b/src/HERMIT/Dictionary/Function.hs
@@ -1,4 +1,7 @@
-{-# LANGUAGE CPP, FlexibleContexts, RankNTypes, ScopedTypeVariables #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
 module HERMIT.Dictionary.Function
     ( externals
     , appArgM

--- a/src/HERMIT/Dictionary/Inline.hs
+++ b/src/HERMIT/Dictionary/Inline.hs
@@ -1,4 +1,7 @@
-{-# LANGUAGE CPP, TupleSections, FlexibleContexts, ScopedTypeVariables #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
+
 module HERMIT.Dictionary.Inline
     ( -- * Inlining
       externals

--- a/src/HERMIT/Dictionary/Local/Case.hs
+++ b/src/HERMIT/Dictionary/Local/Case.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
@@ -38,13 +38,10 @@ module HERMIT.Dictionary.Local.Case
     ) where
 
 import Control.Arrow
-import Control.Monad
+import Control.Monad ((>=>), forM, liftM)
 import Control.Monad.IO.Class
 
-import Data.List
-#if __GLASGOW_HASKELL__ < 710
-import Data.Monoid
-#endif
+import Data.List (intersect, transpose)
 
 import HERMIT.Core
 import HERMIT.Context
@@ -63,6 +60,8 @@ import HERMIT.Dictionary.Fold hiding (externals)
 import HERMIT.Dictionary.Inline hiding (externals)
 import HERMIT.Dictionary.Undefined (verifyStrictT, buildStrictnessLemmaT)
 import HERMIT.Dictionary.Unfold (unfoldR)
+
+import Prelude.Compat hiding ((<$>))
 
 ------------------------------------------------------------------------------
 

--- a/src/HERMIT/Dictionary/Local/Cast.hs
+++ b/src/HERMIT/Dictionary/Local/Cast.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP, FlexibleContexts #-}
+{-# LANGUAGE FlexibleContexts #-}
 
 module HERMIT.Dictionary.Local.Cast
     ( -- * Rewrites on Case Expressions

--- a/src/HERMIT/Dictionary/Local/Let.hs
+++ b/src/HERMIT/Dictionary/Local/Let.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module HERMIT.Dictionary.Local.Let
@@ -46,10 +47,10 @@ module HERMIT.Dictionary.Local.Let
     ) where
 
 import Control.Arrow
-import Control.Monad
+import Control.Monad (ap, liftM, when)
 import Control.Monad.IO.Class
 
-import Data.List
+import Data.List (intersect, partition)
 import Data.Monoid
 
 import HERMIT.Core
@@ -67,6 +68,8 @@ import HERMIT.Dictionary.Inline hiding (externals)
 import HERMIT.Dictionary.AlphaConversion hiding (externals)
 
 import HERMIT.Dictionary.Local.Bind hiding (externals)
+
+import Prelude.Compat hiding ((<$))
 
 ------------------------------------------------------------------------------
 

--- a/src/HERMIT/Dictionary/Local/Let.hs
+++ b/src/HERMIT/Dictionary/Local/Let.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiWayIf #-}
@@ -240,10 +239,8 @@ letNonRecSubstSafeR =
 
          extractT occurrencesT >>^ (getSum >>> (< 2))
 
-#if __GLASGOW_HASKELL__ < 710
 (<$) :: Monad m => a -> m b -> m a
 a <$ mb = mb >> return a
-#endif
 
 -------------------------------------------------------------------------------------------
 

--- a/src/HERMIT/Dictionary/Navigation.hs
+++ b/src/HERMIT/Dictionary/Navigation.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module HERMIT.Dictionary.Navigation
     ( -- * Navigation

--- a/src/HERMIT/Dictionary/Query.hs
+++ b/src/HERMIT/Dictionary/Query.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE CPP, LambdaCase, FlexibleContexts #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 
 module HERMIT.Dictionary.Query
     ( -- * Queries and Predicates

--- a/src/HERMIT/Dictionary/Reasoning.hs
+++ b/src/HERMIT/Dictionary/Reasoning.hs
@@ -56,7 +56,7 @@ module HERMIT.Dictionary.Reasoning
     ) where
 
 import           Control.Arrow hiding ((<+>))
-import           Control.Monad
+import           Control.Monad ((>=>), forM, liftM)
 
 import           Data.Either (partitionEithers)
 import           Data.List (isInfixOf, nubBy)
@@ -68,7 +68,7 @@ import           HERMIT.Context
 import           HERMIT.Core
 import           HERMIT.External
 import           HERMIT.GHC hiding ((<>), (<+>), nest, ($+$))
-import           HERMIT.Kure hiding ((<$>), (<*>))
+import           HERMIT.Kure
 import           HERMIT.Lemma
 import           HERMIT.Monad
 import           HERMIT.Name
@@ -82,7 +82,7 @@ import           HERMIT.Dictionary.Fold hiding (externals)
 import           HERMIT.Dictionary.GHC hiding (externals)
 import           HERMIT.Dictionary.Local.Let (nonRecIntroR)
 
-import           Prelude.Compat
+import           Prelude.Compat hiding ((<$>), (<*>))
 
 import qualified Text.PrettyPrint.MarkedHughesPJ as PP
 

--- a/src/HERMIT/Dictionary/Reasoning.hs
+++ b/src/HERMIT/Dictionary/Reasoning.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
@@ -67,7 +68,7 @@ import           HERMIT.Context
 import           HERMIT.Core
 import           HERMIT.External
 import           HERMIT.GHC hiding ((<>), (<+>), nest, ($+$))
-import           HERMIT.Kure
+import           HERMIT.Kure hiding ((<$>), (<*>))
 import           HERMIT.Lemma
 import           HERMIT.Monad
 import           HERMIT.Name
@@ -80,6 +81,8 @@ import           HERMIT.Dictionary.Common
 import           HERMIT.Dictionary.Fold hiding (externals)
 import           HERMIT.Dictionary.GHC hiding (externals)
 import           HERMIT.Dictionary.Local.Let (nonRecIntroR)
+
+import           Prelude.Compat
 
 import qualified Text.PrettyPrint.MarkedHughesPJ as PP
 

--- a/src/HERMIT/Dictionary/Reasoning.hs
+++ b/src/HERMIT/Dictionary/Reasoning.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}

--- a/src/HERMIT/Dictionary/Rules.hs
+++ b/src/HERMIT/Dictionary/Rules.hs
@@ -1,4 +1,8 @@
-{-# LANGUAGE CPP, DeriveDataTypeable, FlexibleContexts, FlexibleInstances, TypeFamilies #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeFamilies #-}
+
 module HERMIT.Dictionary.Rules
     ( -- * GHC Rewrite Rules and Specialisation
       externals

--- a/src/HERMIT/Dictionary/Unfold.hs
+++ b/src/HERMIT/Dictionary/Unfold.hs
@@ -1,4 +1,8 @@
-{-# LANGUAGE FlexibleContexts, ScopedTypeVariables, TupleSections, LambdaCase #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
+
 module HERMIT.Dictionary.Unfold
     ( externals
     , betaReducePlusR

--- a/src/HERMIT/Dictionary/WorkerWrapper/Common.hs
+++ b/src/HERMIT/Dictionary/WorkerWrapper/Common.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeFamilies #-}
+
 module HERMIT.Dictionary.WorkerWrapper.Common
     ( externals
     , WWAssumptionTag(..)

--- a/src/HERMIT/Dictionary/WorkerWrapper/Fix.hs
+++ b/src/HERMIT/Dictionary/WorkerWrapper/Fix.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
 module HERMIT.Dictionary.WorkerWrapper.Fix
     ( -- * The Worker/Wrapper Transformation
       -- | Note that many of these operations require 'Data.Function.fix' to be in scope.
@@ -19,7 +21,7 @@ import Data.String (fromString)
 import HERMIT.Core
 import HERMIT.External
 import HERMIT.GHC
-import HERMIT.Kure
+import HERMIT.Kure hiding ((<$>))
 import HERMIT.Lemma
 import HERMIT.Monad
 import HERMIT.Name
@@ -36,6 +38,8 @@ import HERMIT.Dictionary.Reasoning
 import HERMIT.Dictionary.Unfold
 
 import HERMIT.Dictionary.WorkerWrapper.Common
+
+import Prelude.Compat
 
 --------------------------------------------------------------------------------------------------
 

--- a/src/HERMIT/Dictionary/WorkerWrapper/FixResult.hs
+++ b/src/HERMIT/Dictionary/WorkerWrapper/FixResult.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TupleSections #-}
 
 module HERMIT.Dictionary.WorkerWrapper.FixResult
@@ -14,7 +15,7 @@ module HERMIT.Dictionary.WorkerWrapper.FixResult
     , wwResultAssC
     ) where
 
-import Prelude hiding (abs)
+import Prelude.Compat hiding (abs)
 
 import Control.Arrow
 
@@ -23,7 +24,7 @@ import Data.String (fromString)
 import HERMIT.Core
 import HERMIT.External
 import HERMIT.GHC
-import HERMIT.Kure
+import HERMIT.Kure hiding ((<$>))
 import HERMIT.Lemma
 import HERMIT.Monad
 import HERMIT.Name

--- a/src/HERMIT/GHC.hs
+++ b/src/HERMIT/GHC.hs
@@ -1,4 +1,7 @@
-{-# LANGUAGE CPP, InstanceSigs, TypeSynonymInstances, FlexibleInstances #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE TypeSynonymInstances #-}
 {-# OPTIONS_GHC -fno-warn-name-shadowing #-}
 -- Above shadowing disabled because the eqExprX function has lots of shadowing
 module HERMIT.GHC
@@ -86,7 +89,7 @@ import           OccurAnal (occurAnalyseExpr_NoBinderSwap)
 import           Pair (Pair(..))
 import           Panic (throwGhcException, throwGhcExceptionIO, GhcException(..))
 import           PrelNames (typeableClassName)
-#if mingw32_HOST_OS
+#ifdef mingw32_HOST_OS
 import           StaticFlags
 #endif
 import           TcEnv (tcLookupClass)

--- a/src/HERMIT/GHC/Typechecker.hs
+++ b/src/HERMIT/GHC/Typechecker.hs
@@ -1,4 +1,6 @@
-{-# LANGUAGE CPP, RankNTypes #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE RankNTypes #-}
+
 module HERMIT.GHC.Typechecker
     (
       initTcFromModGuts

--- a/src/HERMIT/Kernel.hs
+++ b/src/HERMIT/Kernel.hs
@@ -45,21 +45,21 @@ import HERMIT.Monad
 -- | A 'Kernel' is a repository for complete Core syntax trees ('ModGuts') and Lemmas.
 data Kernel = Kernel
   { -- | Halt the 'Kernel' and return control to GHC, which compiles the specified 'AST'.
-    resumeK :: MonadIO m =>                                   AST -> m ()
+    resumeK :: forall m. MonadIO m =>                                   AST -> m ()
     -- | Halt the 'Kernel' and abort GHC without compiling.
-  , abortK  :: MonadIO m =>                                          m ()
+  , abortK  :: forall m. MonadIO m =>                                          m ()
     -- | Apply a 'Rewrite' to the specified 'AST' and return a handle to the resulting 'AST'.
-  , applyK  :: (MonadIO m, MonadCatch m)
-            => RewriteH ModGuts     -> CommitMsg -> KernelEnv -> AST -> m AST
+  , applyK  :: forall m. (MonadIO m, MonadCatch m)
+            => RewriteH ModGuts     -> CommitMsg -> KernelEnv ->        AST -> m AST
     -- | Apply a 'TransformH' to the 'AST', return the resulting value, and potentially a new 'AST'.
-  , queryK  :: (MonadIO m, MonadCatch m)
-            => TransformH ModGuts a -> CommitMsg -> KernelEnv -> AST -> m (AST,a)
+  , queryK  :: forall m a. (MonadIO m, MonadCatch m)
+            => TransformH ModGuts a -> CommitMsg -> KernelEnv ->        AST -> m (AST,a)
     -- | Delete the internal record of the specified 'AST'.
-  , deleteK :: MonadIO m =>                                   AST -> m ()
+  , deleteK :: forall m. MonadIO m =>                                   AST -> m ()
     -- | List all the 'AST's tracked by the 'Kernel', including version data.
-  , listK   :: MonadIO m =>                                          m [(AST,Maybe String, Maybe AST)]
+  , listK   :: forall m. MonadIO m =>                                          m [(AST,Maybe String, Maybe AST)]
     -- | Log a new AST with same Lemmas/ModGuts as given AST.
-  , tellK   :: (MonadIO m, MonadCatch m) => String         -> AST -> m AST
+  , tellK   :: forall m. (MonadIO m, MonadCatch m) => String         -> AST -> m AST
   }
 
 data CommitMsg = Always String | Changed String | Never

--- a/src/HERMIT/Kure.hs
+++ b/src/HERMIT/Kure.hs
@@ -1,9 +1,9 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
@@ -87,12 +87,12 @@ module HERMIT.Kure
     , implT, implAllR
     , equivT, equivAllR
     , forallT, forallR
-#if __GLASGOW_HASKELL__ < 710
       -- * Applicative
     , (<$>)
     , (<*>)
-#endif
     ) where
+
+import Control.Monad (ap, liftM)
 
 import Language.KURE
 import Language.KURE.BiTransform
@@ -107,9 +107,7 @@ import HERMIT.Kure.Universes
 import HERMIT.Lemma
 import HERMIT.Monad
 
-#if __GLASGOW_HASKELL__ < 710
-import Control.Monad
-#endif
+import Prelude.Compat hiding ((<$>), (<*>))
 
 ---------------------------------------------------------------------
 
@@ -119,7 +117,6 @@ type BiRewriteH a   = BiRewrite HermitC HermitM a
 type LensH a b      = Lens      HermitC HermitM a b
 type PathH          = Path Crumb
 
-#if __GLASGOW_HASKELL__ < 710
 -- It is annoying that Applicative is not a superclass of Monad in 7.8.
 -- This causes a warning which we ignore.
 (<$>) :: Monad m => (a -> b) -> m a -> m b
@@ -129,7 +126,6 @@ type PathH          = Path Crumb
 (<*>) :: Monad m => m (a -> b) -> m a -> m b
 (<*>) = ap
 {-# INLINE (<*>) #-}
-#endif
 
 ---------------------------------------------------------------------
 

--- a/src/HERMIT/Kure.hs
+++ b/src/HERMIT/Kure.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module HERMIT.Kure
     ( -- * KURE

--- a/src/HERMIT/Lemma.hs
+++ b/src/HERMIT/Lemma.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 
 module HERMIT.Lemma
     ( -- * Clause
@@ -27,16 +27,13 @@ module HERMIT.Lemma
     , NamedLemma
     ) where
 
-import Prelude hiding (lookup)
+import Prelude.Compat hiding (lookup)
 
 import Control.Monad
 
 import Data.Dynamic (Typeable)
 import Data.String (IsString(..))
 import qualified Data.Map as M
-#if __GLASGOW_HASKELL__ < 710
-import Data.Monoid
-#endif
 
 import HERMIT.Core
 import HERMIT.GHC hiding ((<>))

--- a/src/HERMIT/Libraries/Int.hs
+++ b/src/HERMIT/Libraries/Int.hs
@@ -1,4 +1,6 @@
+{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
+
 module HERMIT.Libraries.Int where
 
 import Control.Arrow
@@ -6,11 +8,13 @@ import Control.Arrow
 import qualified Data.Map as M
 
 import HERMIT.GHC hiding (intTy)
-import HERMIT.Kure
+import HERMIT.Kure hiding ((<$>))
 import HERMIT.Lemma
 import HERMIT.Name
 import HERMIT.Dictionary.Common
 import HERMIT.Dictionary.GHC
+
+import Prelude.Compat
 
 {-
 Defines the following lemmas:

--- a/src/HERMIT/Monad.hs
+++ b/src/HERMIT/Monad.hs
@@ -1,8 +1,8 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 
 module HERMIT.Monad
     ( -- * The HERMIT Monad
@@ -31,11 +31,8 @@ module HERMIT.Monad
     , sendKEnvMessage
     ) where
 
-import Prelude hiding (lookup)
+import Prelude.Compat hiding (lookup)
 
-#if __GLASGOW_HASKELL__ < 710
-import Control.Applicative
-#endif
 import Control.Monad
 import Control.Monad.IO.Class
 

--- a/src/HERMIT/Name.hs
+++ b/src/HERMIT/Name.hs
@@ -1,4 +1,8 @@
-{-# LANGUAGE CPP, DeriveDataTypeable, FlexibleInstances, TypeFamilies #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
 module HERMIT.Name
     ( HermitName
     , cmpHN2Name

--- a/src/HERMIT/Name.hs
+++ b/src/HERMIT/Name.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
@@ -57,8 +58,10 @@ import Data.String (IsString(..))
 import HERMIT.Context
 import HERMIT.External
 import HERMIT.GHC
-import HERMIT.Kure
+import HERMIT.Kure hiding ((<$>), (<*>))
 import HERMIT.Monad
+
+import Prelude.Compat
 
 -- | Possible results from name lookup.
 -- Invariant: One constructor for each NameSpace.

--- a/src/HERMIT/Name.hs
+++ b/src/HERMIT/Name.hs
@@ -58,10 +58,10 @@ import Data.String (IsString(..))
 import HERMIT.Context
 import HERMIT.External
 import HERMIT.GHC
-import HERMIT.Kure hiding ((<$>), (<*>))
+import HERMIT.Kure
 import HERMIT.Monad
 
-import Prelude.Compat
+import Prelude.Compat hiding ((<$>), (<*>))
 
 -- | Possible results from name lookup.
 -- Invariant: One constructor for each NameSpace.

--- a/src/HERMIT/ParserCore.y
+++ b/src/HERMIT/ParserCore.y
@@ -1,5 +1,4 @@
 {
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE TupleSections #-}
 module HERMIT.ParserCore
     ( parseCore

--- a/src/HERMIT/ParserType.y
+++ b/src/HERMIT/ParserType.y
@@ -1,5 +1,4 @@
 {
-{-# LANGUAGE CPP #-}
 module HERMIT.ParserType
     ( parseType
     , parseTypeT

--- a/src/HERMIT/Plugin/Display.hs
+++ b/src/HERMIT/Plugin/Display.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
 module HERMIT.Plugin.Display
     ( display
     , ps_putStr
@@ -10,14 +11,13 @@ import Control.Monad.Reader
 import Control.Monad.State
 
 import Data.Maybe (fromMaybe)
-#if __GLASGOW_HASKELL__ < 710
-import Data.Monoid
-#endif
 
 import HERMIT.Kernel (queryK, CommitMsg(..))
 import HERMIT.Kure
 import HERMIT.Plugin.Types
 import HERMIT.PrettyPrinter.Common
+
+import Prelude.Compat
 
 import System.IO
 

--- a/src/HERMIT/Plugin/Renderer.hs
+++ b/src/HERMIT/Plugin/Renderer.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 
 module HERMIT.Plugin.Renderer where
 
@@ -7,9 +8,6 @@ import Control.Arrow
 import Control.Monad.State
 
 import Data.List (isInfixOf, isPrefixOf, isSuffixOf)
-#if __GLASGOW_HASKELL__ < 710
-import Data.Monoid
-#endif
 
 import HERMIT.Dictionary (traceR)
 import HERMIT.Kure
@@ -18,6 +16,8 @@ import HERMIT.PrettyPrinter.Common
 #ifdef mingw32_HOST_OS
 import HERMIT.Win32.IO (hPutStr, hPutStrLn)
 #endif
+
+import Prelude.Compat
 
 import System.Console.ANSI
 #ifdef mingw32_HOST_OS

--- a/src/HERMIT/Plugin/Types.hs
+++ b/src/HERMIT/Plugin/Types.hs
@@ -1,18 +1,15 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 
 module HERMIT.Plugin.Types where
 
-#if __GLASGOW_HASKELL__ < 710
-import Control.Applicative
-#endif
 import Control.Concurrent.STM
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.IO.Class (MonadIO(..))
@@ -31,6 +28,8 @@ import HERMIT.Monad
 import HERMIT.Plugin.Builder
 import HERMIT.PrettyPrinter.Common
 import HERMIT.Dictionary.Reasoning
+
+import Prelude.Compat
 
 import System.IO
 

--- a/src/HERMIT/PrettyPrinter/AST.hs
+++ b/src/HERMIT/PrettyPrinter/AST.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE CPP #-}
-
 -- | Output the raw Expr constructors. Helpful for writing pattern matching rewrites.
 module HERMIT.PrettyPrinter.AST
   ( -- * HERMIT's AST Pretty-Printer for GHC Core

--- a/src/HERMIT/PrettyPrinter/Clean.hs
+++ b/src/HERMIT/PrettyPrinter/Clean.hs
@@ -27,12 +27,12 @@ import HERMIT.Context
 import HERMIT.Core
 import HERMIT.External
 import HERMIT.GHC hiding ((<+>), (<>), ($$), ($+$), cat, sep, fsep, hsep, empty, nest, vcat, char, text, keyword, hang)
-import HERMIT.Kure
+import HERMIT.Kure hiding ((<$>))
 import HERMIT.Monad
 import HERMIT.PrettyPrinter.Common
 import HERMIT.Syntax
 
-import Prelude.Compat hiding ((<$>))
+import Prelude.Compat
 
 import Text.PrettyPrint.MarkedHughesPJ as PP
 

--- a/src/HERMIT/PrettyPrinter/Clean.hs
+++ b/src/HERMIT/PrettyPrinter/Clean.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 
 module HERMIT.PrettyPrinter.Clean
     ( -- * HERMIT's Clean Pretty-Printer for GHC Core
@@ -22,9 +22,6 @@ import Control.Arrow hiding ((<+>))
 
 import Data.Char (isSpace)
 import Data.Default.Class
-#if __GLASGOW_HASKELL__ < 710
-import Data.Monoid (mempty)
-#endif
 
 import HERMIT.Context
 import HERMIT.Core
@@ -34,6 +31,8 @@ import HERMIT.Kure
 import HERMIT.Monad
 import HERMIT.PrettyPrinter.Common
 import HERMIT.Syntax
+
+import Prelude.Compat hiding ((<$>))
 
 import Text.PrettyPrint.MarkedHughesPJ as PP
 

--- a/src/HERMIT/PrettyPrinter/Common.hs
+++ b/src/HERMIT/PrettyPrinter/Common.hs
@@ -1,10 +1,10 @@
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module HERMIT.PrettyPrinter.Common
     ( -- * Documents
@@ -57,9 +57,6 @@ module HERMIT.PrettyPrinter.Common
 
 import Data.Char
 import Data.Default.Class
-#if __GLASGOW_HASKELL__ < 710
-import Data.Monoid hiding ((<>))
-#endif
 import qualified Data.Map as M
 import Data.Typeable
 
@@ -70,6 +67,8 @@ import HERMIT.GHC hiding (($$), (<>), (<+>), char)
 import HERMIT.Kure
 import HERMIT.Lemma
 import HERMIT.Monad
+
+import Prelude.Compat
 
 import Text.PrettyPrint.MarkedHughesPJ as PP
 

--- a/src/HERMIT/Shell/Command.hs
+++ b/src/HERMIT/Shell/Command.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -22,14 +23,14 @@ module HERMIT.Shell.Command
     , evalScript
     ) where
 
-import Control.Monad.State
+import Control.Monad ((>=>), when)
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Trans.Class (lift)
+import Control.Monad.State (get, gets, modify)
 
 import Data.Char
 import Data.List (isPrefixOf, partition)
 import Data.Maybe
-#if __GLASGOW_HASKELL__ < 710
-import Data.Monoid
-#endif
 
 import HERMIT.Context
 import HERMIT.External
@@ -53,6 +54,8 @@ import HERMIT.Shell.Types
 #ifdef mingw32_HOST_OS
 import HERMIT.Win32.Console
 #endif
+
+import Prelude.Compat
 
 import System.IO
 

--- a/src/HERMIT/Shell/Completion.hs
+++ b/src/HERMIT/Shell/Completion.hs
@@ -1,14 +1,14 @@
 {-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
 module HERMIT.Shell.Completion (completer) where
 
-#if __GLASGOW_HASKELL__ < 710
-import Control.Applicative
-#endif
 import Control.Arrow
-import Control.Monad.State
+import Control.Monad (forM, liftM)
+import Control.Monad.IO.Class (MonadIO(..))
+import Control.Monad.State (gets)
 
 import Data.Dynamic
 import Data.List (isPrefixOf, nub)
@@ -29,6 +29,8 @@ import HERMIT.Dictionary.Rules
 import HERMIT.Shell.Interpreter
 import HERMIT.Shell.Proof
 import HERMIT.Shell.Types
+
+import Prelude.Compat
 
 import System.Console.Haskeline hiding (catch, display)
 

--- a/src/HERMIT/Shell/Externals.hs
+++ b/src/HERMIT/Shell/Externals.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module HERMIT.Shell.Externals where
@@ -13,9 +13,6 @@ import Data.Dynamic (fromDynamic)
 import Data.List (intercalate)
 import qualified Data.Map as M
 import Data.Maybe (fromMaybe)
-#if __GLASGOW_HASKELL__ < 710
-import Data.Monoid (mempty)
-#endif
 
 import HERMIT.External
 import HERMIT.Kernel
@@ -34,6 +31,8 @@ import HERMIT.Shell.Proof as Proof
 import HERMIT.Shell.ScriptToRewrite
 import HERMIT.Shell.ShellEffect
 import HERMIT.Shell.Types
+
+import Prelude.Compat
 
 ----------------------------------------------------------------------------------
 

--- a/src/HERMIT/Shell/Proof.hs
+++ b/src/HERMIT/Shell/Proof.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
@@ -33,9 +33,6 @@ import Control.Monad.State (MonadState(get), modify, gets)
 import Data.Dynamic
 import Data.Function (on)
 import Data.List (nubBy)
-#if __GLASGOW_HASKELL__ < 710
-import Data.Monoid
-#endif
 
 import HERMIT.Context
 import HERMIT.External
@@ -51,6 +48,8 @@ import HERMIT.Dictionary.Reasoning hiding (externals)
 import HERMIT.Plugin.Types
 import HERMIT.Shell.ShellEffect
 import HERMIT.Shell.Types
+
+import Prelude.Compat
 
 --------------------------------------------------------------------------------------------------------
 

--- a/src/HERMIT/Shell/ScriptToRewrite.hs
+++ b/src/HERMIT/Shell/ScriptToRewrite.hs
@@ -23,7 +23,7 @@ module HERMIT.Shell.ScriptToRewrite
     ) where
 
 import Control.Arrow
-import Control.Monad
+import Control.Monad (forM)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Reader (asks)
 import Control.Monad.State (MonadState, gets, modify)
@@ -35,7 +35,7 @@ import qualified Data.Map as M
 import HERMIT.Context (LocalPathH, getAntecedents)
 import HERMIT.External
 import HERMIT.Kernel
-import HERMIT.Kure hiding ((<$>))
+import HERMIT.Kure
 import HERMIT.Lemma
 import HERMIT.Parser(Script, ExprH, unparseExprH, parseScript, unparseScript)
 import HERMIT.Dictionary.Reasoning
@@ -48,7 +48,7 @@ import HERMIT.Shell.Interpreter
 import HERMIT.Shell.ShellEffect
 import HERMIT.Shell.Types
 
-import Prelude.Compat
+import Prelude.Compat hiding ((<$>))
 
 import qualified Text.PrettyPrint.MarkedHughesPJ as PP
 ------------------------------------

--- a/src/HERMIT/Shell/ScriptToRewrite.hs
+++ b/src/HERMIT/Shell/ScriptToRewrite.hs
@@ -1,5 +1,11 @@
-{-# LANGUAGE ConstraintKinds, DeriveDataTypeable, FlexibleContexts, LambdaCase,
-             MultiParamTypeClasses, ScopedTypeVariables, TypeFamilies #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module HERMIT.Shell.ScriptToRewrite
     ( -- * Converting Scripts to Rewrites
@@ -29,7 +35,7 @@ import qualified Data.Map as M
 import HERMIT.Context (LocalPathH, getAntecedents)
 import HERMIT.External
 import HERMIT.Kernel
-import HERMIT.Kure
+import HERMIT.Kure hiding ((<$>))
 import HERMIT.Lemma
 import HERMIT.Parser(Script, ExprH, unparseExprH, parseScript, unparseScript)
 import HERMIT.Dictionary.Reasoning
@@ -41,6 +47,8 @@ import HERMIT.Shell.KernelEffect
 import HERMIT.Shell.Interpreter
 import HERMIT.Shell.ShellEffect
 import HERMIT.Shell.Types
+
+import Prelude.Compat
 
 import qualified Text.PrettyPrint.MarkedHughesPJ as PP
 ------------------------------------

--- a/src/HERMIT/Shell/Types.hs
+++ b/src/HERMIT/Shell/Types.hs
@@ -8,16 +8,15 @@
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module HERMIT.Shell.Types where
 
-#if __GLASGOW_HASKELL__ < 710
-import Control.Applicative (Applicative)
-#endif
 import Control.Arrow
 import Control.Concurrent.STM
 import Control.Monad (liftM, unless, when, forM_, forM, unless)
@@ -31,9 +30,6 @@ import Control.Monad.Trans.Except (ExceptT(..), runExceptT)
 import Data.Dynamic
 import qualified Data.Map as M
 import Data.Maybe (fromMaybe, isJust)
-#if __GLASGOW_HASKELL__ < 710
-import Data.Monoid (mempty)
-#endif
 
 import HERMIT.Context
 import HERMIT.Core
@@ -50,6 +46,8 @@ import HERMIT.PrettyPrinter.Common
 import HERMIT.Plugin.Display
 import HERMIT.Plugin.Renderer
 import HERMIT.Plugin.Types
+
+import Prelude.Compat hiding ((<$>))
 
 import System.Console.Haskeline hiding (catch, display)
 import System.IO (Handle, stdout)

--- a/src/HERMIT/Win32/IO.hsc
+++ b/src/HERMIT/Win32/IO.hsc
@@ -1,5 +1,5 @@
 -- | Adapted from circular-ruin's StackOverflow answer at <http://stackoverflow.com/a/10779150>
-{-# LANGUAGE ForeignFunctionInterface, CPP, NoImplicitPrelude #-}
+{-# LANGUAGE ForeignFunctionInterface #-}
 module HERMIT.Win32.IO (
     HERMIT.Win32.IO.putChar
   , HERMIT.Win32.IO.putStr


### PR DESCRIPTION
Currently, `hermit` uses a lot of `#if __GLASGOW_HASKELL__ < 710` pragmas to conditionally import modules which are exported by `Prelude` in `base-4.8.0.0`. To reduce the number of CPP pragmas in the codebase, I use the `Prelude.Compat` module from `base-compat` (which backports the latest version of `Prelude`).