### PR TITLE
Moved RULES to Main modules (and removed a couple INLINEs)

### DIFF
--- a/examples/concatVanishes/Flatten.hs
+++ b/examples/concatVanishes/Flatten.hs
@@ -11,3 +11,14 @@ flatten (Node l r) = flatten l ++ flatten r
 
 main :: IO ()
 main = print (flatten (Node (Leaf 'h') (Leaf 'i')))
+
+
+-- Should be in the "List" module
+{-# RULES "++ []"  forall xs .  xs ++ [] = xs #-}
+{-# RULES "++ strict"           (++) undefined = undefined #-}
+
+-- The "Algebra" for repH
+{-# RULES "repH ++" forall xs ys .     repH (xs ++ ys) = repH xs . repH ys #-}
+{-# RULES "repH []"                    repH [] = id                        #-}
+{-# RULES "repH (:)" forall x xs .     repH (x:xs) = ((:) x) . repH xs     #-}
+

--- a/examples/concatVanishes/HList.hs
+++ b/examples/concatVanishes/HList.hs
@@ -14,11 +14,11 @@ repH xs = (xs ++)
 absH :: H a -> [a]
 absH f = f []
 
--- Should be in the "List" module
-{-# RULES "++ []"  forall xs .  xs ++ [] = xs #-}
-{-# RULES "++ strict"           (++) undefined = undefined #-}
+-- -- Should be in the "List" module
+-- {-# RULES "++ []"  forall xs .  xs ++ [] = xs #-}
+-- {-# RULES "++ strict"           (++) undefined = undefined #-}
 
--- The "Algebra" for repH
-{-# RULES "repH ++" forall xs ys .     repH (xs ++ ys) = repH xs . repH ys #-}
-{-# RULES "repH []"                    repH [] = id                        #-}
-{-# RULES "repH (:)" forall x xs .     repH (x:xs) = ((:) x) . repH xs     #-}
+-- -- The "Algebra" for repH
+-- {-# RULES "repH ++" forall xs ys .     repH (xs ++ ys) = repH xs . repH ys #-}
+-- {-# RULES "repH []"                    repH [] = id                        #-}
+-- {-# RULES "repH (:)" forall x xs .     repH (x:xs) = ((:) x) . repH xs     #-}

--- a/examples/concatVanishes/QSort.hs
+++ b/examples/concatVanishes/QSort.hs
@@ -15,3 +15,11 @@ qsort (a:as) = qsort bs ++ [a] ++ qsort cs
 main :: IO ()
 main = print (qsort [8,3,5,7,2,9,4,6,3,2])
 
+-- Should be in the "List" module
+{-# RULES "++ []"  forall xs .  xs ++ [] = xs #-}
+{-# RULES "++ strict"           (++) undefined = undefined #-}
+
+-- The "Algebra" for repH
+{-# RULES "repH ++" forall xs ys .     repH (xs ++ ys) = repH xs . repH ys #-}
+{-# RULES "repH []"                    repH [] = id                        #-}
+{-# RULES "repH (:)" forall x xs .     repH (x:xs) = ((:) x) . repH xs     #-}

--- a/examples/concatVanishes/Rev.hs
+++ b/examples/concatVanishes/Rev.hs
@@ -10,3 +10,13 @@ rev (y:ys) = rev ys ++ [y]
 main :: IO ()
 main = print $ rev [1..10]
 
+
+-- Should be in the "List" module
+{-# RULES "++ []"  forall xs .  xs ++ [] = xs #-}
+{-# RULES "++ strict"           (++) undefined = undefined #-}
+
+-- The "Algebra" for repH
+{-# RULES "repH ++" forall xs ys .     repH (xs ++ ys) = repH xs . repH ys #-}
+{-# RULES "repH []"                    repH [] = id                        #-}
+{-# RULES "repH (:)" forall x xs .     repH (x:xs) = ((:) x) . repH xs     #-}
+

--- a/examples/flatten/Flatten.hs
+++ b/examples/flatten/Flatten.hs
@@ -11,3 +11,14 @@ flatten (Node l r) = flatten l ++ flatten r
 
 main :: IO ()
 main = print (flatten (Node (Leaf 'h') (Leaf 'i')))
+
+
+-- Should be in a "List" module
+{-# RULES "++ []"  forall xs .  xs ++ [] = xs #-}
+{-# RULES "++ strict"           (++) undefined = undefined #-}
+
+-- The "Algebra" for repH
+{-# RULES "repH ++" forall xs ys   . repH (xs ++ ys) = repH xs . repH ys #-}
+{-# RULES "repH []"                  repH [] = id                        #-}
+{-# RULES "repH (:)" forall x xs   . repH (x:xs) = ((:) x) . repH xs     #-}
+

--- a/examples/flatten/HList.hs
+++ b/examples/flatten/HList.hs
@@ -14,11 +14,11 @@ repH xs = (xs ++)
 absH :: H a -> [a]
 absH f = f []
 
--- Should be in a "List" module
-{-# RULES "++ []"  forall xs .  xs ++ [] = xs #-}
-{-# RULES "++ strict"           (++) undefined = undefined #-}
+-- -- Should be in a "List" module
+-- {-# RULES "++ []"  forall xs .  xs ++ [] = xs #-}
+-- {-# RULES "++ strict"           (++) undefined = undefined #-}
 
--- The "Algebra" for repH
-{-# RULES "repH ++" forall xs ys   . repH (xs ++ ys) = repH xs . repH ys #-}
-{-# RULES "repH []"                  repH [] = id                        #-}
-{-# RULES "repH (:)" forall x xs   . repH (x:xs) = ((:) x) . repH xs     #-}
+-- -- The "Algebra" for repH
+-- {-# RULES "repH ++" forall xs ys   . repH (xs ++ ys) = repH xs . repH ys #-}
+-- {-# RULES "repH []"                  repH [] = id                        #-}
+-- {-# RULES "repH (:)" forall x xs   . repH (x:xs) = ((:) x) . repH xs     #-}

--- a/examples/new_reverse/HList.hs
+++ b/examples/new_reverse/HList.hs
@@ -7,11 +7,11 @@ module HList
 
 type H a = [a] -> [a]
 
-{-# INLINABLE repH #-}
+-- {-# INLINABLE repH #-}
 repH :: [a] -> H a
 repH xs = (xs ++)
 
-{-# INLINABLE absH #-}
+-- {-# INLINABLE absH #-}
 absH :: H a -> [a]
 absH f = f []
 
@@ -19,12 +19,12 @@ absH f = f []
 myAppend :: [a] -> [a] -> [a]
 myAppend []     ys = ys
 myAppend (x:xs) ys = x : myAppend xs ys
-{-# RULES "appendFix" [~] (++) = myAppend #-}
+-- {-# RULES "appendFix" [~] (++) = myAppend #-}
 
--- Algebra for repH
-{-# RULES "repH []"  [~]               repH [] = id #-}
-{-# RULES "repH (:)" [~] forall x xs.  repH (x:xs) = (x:) . repH xs #-}
-{-# RULES "repH ++"  [~] forall xs ys. repH (xs ++ ys) = repH xs . repH ys #-}
+-- -- Algebra for repH
+-- {-# RULES "repH []"  [~]               repH [] = id #-}
+-- {-# RULES "repH (:)" [~] forall x xs.  repH (x:xs) = (x:) . repH xs #-}
+-- {-# RULES "repH ++"  [~] forall xs ys. repH (xs ++ ys) = repH xs . repH ys #-}
 
--- Needed because the fusion rule we generate isn't too useful yet.
-{-# RULES "repH-absH-fusion" [~] forall h. repH (absH h) = h #-}
+-- -- Needed because the fusion rule we generate isn't too useful yet.
+-- {-# RULES "repH-absH-fusion" [~] forall h. repH (absH h) = h #-}

--- a/examples/new_reverse/Reverse.hs
+++ b/examples/new_reverse/Reverse.hs
@@ -21,3 +21,15 @@ main = print $ rev [1..10]
 -- useful auxilliary lemma for proving the w/w assumption
 {-# RULES "++ []" [~] forall xs. xs ++ [] = xs #-}
 {-# RULES "myAppend-assoc" [~] forall xs ys zs. myAppend (myAppend xs ys) zs = myAppend xs (myAppend ys zs) #-}
+
+
+{-# RULES "appendFix" [~] (++) = myAppend #-}
+
+-- Algebra for repH
+{-# RULES "repH []"  [~]               repH [] = id #-}
+{-# RULES "repH (:)" [~] forall x xs.  repH (x:xs) = (x:) . repH xs #-}
+{-# RULES "repH ++"  [~] forall xs ys. repH (xs ++ ys) = repH xs . repH ys #-}
+
+-- Needed because the fusion rule we generate isn't too useful yet.
+{-# RULES "repH-absH-fusion" [~] forall h. repH (absH h) = h #-}
+

--- a/examples/qsort/HList.hs
+++ b/examples/qsort/HList.hs
@@ -6,22 +6,22 @@ module HList
 
 type H a = [a] -> [a]
 
-{-# INLINE repH #-}
+-- {-# INLINE repH #-}
 repH :: [a] -> H a
 repH xs = (xs ++)
 
-{-# INLINE absH #-}
+-- {-# INLINE absH #-}
 absH :: H a -> [a]
 absH f = f []
 
--- Should be in a "List" module
-{-# RULES "++ []"  forall xs .  xs ++ [] = xs #-}
-{-# RULES "++ strict"           (++) undefined = undefined #-}
+-- -- Should be in a "List" module
+-- {-# RULES "++ []"  forall xs .  xs ++ [] = xs #-}
+-- {-# RULES "++ strict"           (++) undefined = undefined #-}
 
--- The "Algebra" for repH
-{-# RULES "repH ++" forall xs ys   . repH (xs ++ ys) = repH xs . repH ys #-}
-{-# RULES "repH []"                  repH [] = id                        #-}
-{-# RULES "repH (:)" forall x xs   . repH (x:xs) = ((:) x) . repH xs     #-}
+-- -- The "Algebra" for repH
+-- {-# RULES "repH ++" forall xs ys   . repH (xs ++ ys) = repH xs . repH ys #-}
+-- {-# RULES "repH []"                  repH [] = id                        #-}
+-- {-# RULES "repH (:)" forall x xs   . repH (x:xs) = ((:) x) . repH xs     #-}
 
--- Needed because the fusion rule we generate isn't too useful yet.
-{-# RULES "repH-absH-fusion" [~] forall h. repH (absH h) = h #-}
+-- -- Needed because the fusion rule we generate isn't too useful yet.
+-- {-# RULES "repH-absH-fusion" [~] forall h. repH (absH h) = h #-}

--- a/examples/qsort/QSort.hs
+++ b/examples/qsort/QSort.hs
@@ -23,3 +23,16 @@ qsort (a:as) = qsort bs ++ [a] ++ qsort cs
 
 main :: IO ()
 main = print (qsort [8,3,5,7,2,9,4,6,3,2])
+
+-- Should be in a "List" module
+{-# RULES "++ []"  forall xs .  xs ++ [] = xs #-}
+{-# RULES "++ strict"           (++) undefined = undefined #-}
+
+-- The "Algebra" for repH
+{-# RULES "repH ++" forall xs ys   . repH (xs ++ ys) = repH xs . repH ys #-}
+{-# RULES "repH []"                  repH [] = id                        #-}
+{-# RULES "repH (:)" forall x xs   . repH (x:xs) = ((:) x) . repH xs     #-}
+
+-- Needed because the fusion rule we generate isn't too useful yet.
+{-# RULES "repH-absH-fusion" [~] forall h. repH (absH h) = h #-}
+

--- a/examples/reverse/HList.hs
+++ b/examples/reverse/HList.hs
@@ -6,19 +6,19 @@ module HList
 
 type H a = [a] -> [a]
 
-{-# INLINE repH #-}
+-- {-# INLINE repH #-}
 repH :: [a] -> H a
 repH xs = (xs ++)
 
-{-# INLINE absH #-}
+-- {-# INLINE absH #-}
 absH :: H a -> [a]
 absH f = f []
 
--- Should be in a "List" module
-{-# RULES "++ []"  forall xs .  xs ++ [] = xs #-}
-{-# RULES "++ strict"           (++) undefined = undefined #-}
+-- -- Should be in a "List" module
+-- {-# RULES "++ []"  forall xs .  xs ++ [] = xs #-}
+-- {-# RULES "++ strict"           (++) undefined = undefined #-}
 
--- The "Algebra" for repH
-{-# RULES "repH ++" forall xs ys   . repH (xs ++ ys) = repH xs . repH ys #-}
-{-# RULES "repH []"                  repH [] = id                        #-}
-{-# RULES "repH (:)" forall x xs   . repH (x:xs) = ((:) x) . repH xs     #-}
+-- -- The "Algebra" for repH
+-- {-# RULES "repH ++" forall xs ys   . repH (xs ++ ys) = repH xs . repH ys #-}
+-- {-# RULES "repH []"                  repH [] = id                        #-}
+-- {-# RULES "repH (:)" forall x xs   . repH (x:xs) = ((:) x) . repH xs     #-}

--- a/examples/reverse/Reverse.hs
+++ b/examples/reverse/Reverse.hs
@@ -10,3 +10,13 @@ rev (x:xs) = rev xs ++ [x]
 
 main :: IO ()
 main = print $ rev "hello"
+
+
+-- Should be in a "List" module
+{-# RULES "++ []"  forall xs .  xs ++ [] = xs #-}
+{-# RULES "++ strict"           (++) undefined = undefined #-}
+
+-- The "Algebra" for repH
+{-# RULES "repH ++" forall xs ys   . repH (xs ++ ys) = repH xs . repH ys #-}
+{-# RULES "repH []"                  repH [] = id                        #-}
+{-# RULES "repH (:)" forall x xs   . repH (x:xs) = ((:) x) . repH xs     #-}


### PR DESCRIPTION
It looks like moving the `RULES` into the module with `main` fixes the issues from #141. I also had to remove a couple `INLINE` and `INLINEABLE` pragmas (but not all of them, strangely).

All of the tests pass on 7.10.2 with this workaround, so it might be a solution we can use temporarily. It seems to work ok on 7.10.1 as well.