### PR TITLE
Ghc head compat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,5 @@ tests/dump/*.dump
 *.dump-prep
 .cabal-sandbox
 cabal.sandbox.config
+tags
 

--- a/src/HERMIT/GHC.hs
+++ b/src/HERMIT/GHC.hs
@@ -93,6 +93,10 @@ import           StaticFlags
 #endif
 import           TcEnv (tcLookupClass)
 import           TcErrors (reportAllUnsolved)
+#if __GLASGOW_HASKELL__ < 710 || (__GLASGOW_HASKELL__ == 710 && __GLASGOW_HASKELL_PATCHLEVEL1__ <= 2)
+import           ErrUtils (pprErrMsgBag)
+import           TcRnMonad (getCtLoc, initIfaceTcRn)
+#endif
 #if __GLASGOW_HASKELL__ < 710
 import           TcMType (newWantedEvVar)
 #else
@@ -315,7 +319,7 @@ lookupRdrNameInModule hsc_env guts mod_name rdr_name = do
     -- First find the package the module resides in by searching exposed packages and home modules
     found_module <- findImportedModule hsc_env mod_name Nothing
     case found_module of
-#if __GLASGOW_HASKELL__ == 710 && __GLASGOW_HASKELL_PATCHLEVEL1__ <= 2
+#if __GLASGOW_HASKELL__ < 710 || (__GLASGOW_HASKELL__ == 710 && __GLASGOW_HASKELL_PATCHLEVEL1__ <= 2)
         Found _ mod -> do
 #else
         FoundModule (FoundHs _ mod) -> do
@@ -330,7 +334,7 @@ lookupRdrNameInModule hsc_env guts mod_name rdr_name = do
                     -- Try and find the required name in the exports
                     let decl_spec = ImpDeclSpec { is_mod = mod_name, is_as = mod_name
                                                 , is_qual = False, is_dloc = noSrcSpan }
-#if __GLASGOW_HASKELL__ == 710 && __GLASGOW_HASKELL_PATCHLEVEL1__ <= 2
+#if __GLASGOW_HASKELL__ < 710 || (__GLASGOW_HASKELL__ == 710 && __GLASGOW_HASKELL_PATCHLEVEL1__ <= 2)
                         provenance = Imported [ImpSpec decl_spec ImpAll]
 #else
                         provenance = Just $ ImpSpec decl_spec ImpAll
@@ -360,7 +364,7 @@ injectDependency hsc_env guts mod_name = do
     -- First find the package the module resides in by searching exposed packages and home modules
     found_module <- findImportedModule hsc_env mod_name Nothing
     case found_module of
-#if __GLASGOW_HASKELL__ == 710 && __GLASGOW_HASKELL_PATCHLEVEL1__ <= 2
+#if __GLASGOW_HASKELL__ < 710 || (__GLASGOW_HASKELL__ == 710 && __GLASGOW_HASKELL_PATCHLEVEL1__ <= 2)
         Found _ mod -> do
 #else
         FoundModule (FoundHs _ mod) -> do

--- a/src/HERMIT/GHC/Typechecker.hs
+++ b/src/HERMIT/GHC/Typechecker.hs
@@ -60,7 +60,11 @@ initTcFromModGuts hsc_env guts hsc_src keep_rn_syntax do_this
         used_rdr_var <- newIORef Set.empty ;
         th_var       <- newIORef False ;
         th_splice_var<- newIORef False ;
+#if __GLASGOW_HASKELL__ < 710 || (__GLASGOW_HASKELL__ == 710 && __GLASGOW_HASKELL_PATCHLEVEL1__ <= 2)
         infer_var    <- newIORef True ;
+#else
+        infer_var    <- newIORef (True, emptyBag) ;
+#endif
         lie_var      <- newIORef emptyWC ;
         dfun_n_var   <- newIORef (mk_dfun_n guts) ;
         type_env_var <- newIORef type_env ;
@@ -107,7 +111,7 @@ initTcFromModGuts hsc_env guts hsc_src keep_rn_syntax do_this
                 tcg_inst_env       = mg_inst_env guts,
                 tcg_fam_inst_env   = mg_fam_inst_env guts,
                 tcg_ann_env        = emptyAnnEnv,
-#if __GLASGOW_HASKELL__ >= 710
+#if __GLASGOW_HASKELL__ == 710 && __GLASGOW_HASKELL_PATCHLEVEL1__ <= 2
                 tcg_visible_orphan_mods = mkModuleSet [mod],
 #endif
                 tcg_dfun_n         = dfun_n_var,
@@ -144,6 +148,9 @@ initTcFromModGuts hsc_env guts hsc_src keep_rn_syntax do_this
                 tcg_rn_imports     = [],
                 tcg_rn_exports     = maybe_rn_syntax [],
                 tcg_keep           = keep_var,
+#if __GLASGOW_HASKELL__ >= 710 && __GLASGOW_HASKELL_PATCHLEVEL1__ > 2
+                tcg_self_boot  = NoSelfBoot, -- Assume there are no hsboot files
+#endif
                 tcg_th_splice_used = th_splice_var
              } ;
              lcl_env = TcLclEnv {

--- a/src/HERMIT/Monad.hs
+++ b/src/HERMIT/Monad.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE CPP #-}
 
 module HERMIT.Monad
     ( -- * The HERMIT Monad
@@ -251,6 +252,10 @@ runTcM m = do
                                                  $    text "Errors:" : pprErrMsgBag errs
                                                    ++ text "Warnings:" : pprErrMsgBag warns
     maybe (fail $ showMsgs msgs) return mr
+#if __GLASGOW_HASKELL__ > 710 || (__GLASGOW_HASKELL__ == 710 && __GLASGOW_HASKELL_PATCHLEVEL1__ > 2)
+   where
+     pprErrMsgBag = pprErrMsgBagWithLoc
+#endif
 
 runDsM :: (HasDynFlags m, HasHermitMEnv m, LiftCoreM m, MonadIO m) => DsM a -> m a
 runDsM = runTcM . initDsTc

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -35,7 +35,11 @@ hermitTests = testGroup "HERMIT tests" $ map mkHermitTest testArgs
 
 -- subdirectory names
 golden, dump, rootDir, examples :: FilePath
+#if __GLASGOW_HASKELL__ > 710 || (__GLASGOW_HASKELL__ == 710 && __GLASGOW_HASKELL_PATCHLEVEL1__ > 2)
+golden   = "golden-ghc-7.11"
+#else
 golden   = "golden"
+#endif
 dump     = "dump"
 rootDir  = "tests"
 examples = "examples"

--- a/tests/golden-ghc-7.11/concatVanishes_Flatten_hs_Flatten_hss.ref
+++ b/tests/golden-ghc-7.11/concatVanishes_Flatten_hs_Flatten_hss.ref
@@ -1,0 +1,54 @@
+===================== Welcome to HERMIT ======================
+HERMIT is a toolkit for the interactive transformation of GHC
+core language programs. Documentation on HERMIT can be found
+on the HERMIT web page at:
+http://www.ittc.ku.edu/csdl/fpg/software/hermit.html
+
+You have just loaded the interactive shell. To exit, type 
+"abort" or "resume" to abort or resume GHC compilation.
+
+Type "help" for instructions on how to list or search the
+available HERMIT commands.
+
+To get started, you could try the following:
+  - type "binding-of 'foo", where "foo" is a function
+    defined in the module;
+  - type "set-pp-type Show" to display full type information;
+  - type "info" for more information about the current node;
+  - to descend into a child node, type the name of the child
+    ("info" includes a list of children of the current node);
+  - to ascend, use the "up" command;
+  - type "log" to display an activity log.
+==============================================================
+
+[0m[1;34mrec[22m[0m[0m [0m[mflatten[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[31m.[0m[0m [0m[32mTree[0m[0m [0m[0m[32ma[0m[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m
+    [0m[mflatten[0m[0m [0m[31m=[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[32ma[0m[0m [0m[31m[31m→[31m[0m[0m
+      [0m[1;34mlet[22m[0m[0m [0m[1;34mrec[22m[0m[0m [0m[mwork[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32mTree[0m[0m [0m[0m[32ma[0m[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m
+              [0m[mwork[0m[0m [0m[31m=[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[mx1[0m[0m [0m[macc[0m[0m [0m[31m[31m→[31m[0m[0m
+                [0m[1;34mcase[22m[0m[0m [0m[0m[mx1[0m[0m[0m [0m[1;34mof[22m[0m[0m [0m[mwild[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m
+                  [0m[mNode[0m[0m [0m[ml[0m[0m [0m[mr[0m[0m [0m[31m[31m→[31m[0m[0m [0m[0m[mwork[0m[0m[0m [0m[0m[ml[0m[0m[0m [0m[31m([0m[0m[0m[0m[mwork[0m[0m[0m [0m[0m[mr[0m[0m[0m [0m[0m[macc[0m[0m[0m[0m[31m)[0m[0m
+                  [0m[mLeaf[0m[0m [0m[ma[0m[0m [0m[31m[31m→[31m[0m[0m [0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[ma[0m[0m[0m [0m[0m[macc[0m[0m[0m
+      [0m[1;34min[22m[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[mx0[0m[0m [0m[31m[31m→[31m[0m[0m [0m[0m[mwork[0m[0m[0m [0m[0m[mx0[0m[0m[0m [0m[31m([0m[0m[0m[m[][0m[0m [0m[0m[32ma[0m[0m[0m[0m[31m)[0m[0m
+[0m[m$dShow[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32mShow[0m[0m [0m[32m[[0m[0m[0m[32mChar[0m[0m[0m[32m][0m[0m
+[0m[m$dShow[0m[0m [0m[31m=[0m[0m [0m[m$fShow[][0m[0m [0m[32mChar[0m[0m [0m[m$fShowChar[0m[0m
+[0m[mmain[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32mIO[0m[0m [0m[32m([0m[0m[0m[32m)[0m[0m
+[0m[mmain[0m[0m [0m[31m=[0m[0m
+  [0m[mprint[0m[0m [0m[32m[[0m[0m[0m[32mChar[0m[0m[0m[32m][0m[0m [0m[0m[m$dShow[0m[0m[0m
+        [0m[31m([0m[0m[0m[0m[mflatten[0m[0m[0m [0m[32mChar[0m[0m
+                 [0m[31m([0m[0m[0m[mNode[0m[0m [0m[32mChar[0m[0m [0m[31m([0m[0m[0m[mLeaf[0m[0m [0m[32mChar[0m[0m [0m[31m([0m[0m[0m[mC#[0m[0m [0m'h'#[0m[0m[31m)[0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[mLeaf[0m[0m [0m[32mChar[0m[0m [0m[31m([0m[0m[0m[mC#[0m[0m [0m'i'#[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m
+[0m[mmain[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32mIO[0m[0m [0m[32m([0m[0m[0m[32m)[0m[0m
+[0m[mmain[0m[0m [0m[31m=[0m[0m [0m[mrunMainIO[0m[0m [0m[32m([0m[0m[0m[32m)[0m[0m [0m[0m[mmain[0m[0m[0m[0m
+++ [] (Not Proven)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[mxs[0m[0m[0m[31m.[0m[0m [0m[31m([0m[0m[0m[m++[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mxs[0m[0m[0m [0m[31m([0m[0m[0m[m[][0m[0m [0m[0m[32ma[0m[0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[0m[mxs[0m[0m[0m
+++ strict (Not Proven)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m[0m[31m.[0m[0m [0m[31m([0m[0m[0m[m++[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[mundefined[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[mundefined[0m[0m [0m[31m([0m[0m[0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m[0m[31m)[0m[0m
+recursive-definition-of-work-for-use-by-ww-fusion (Proven)
+  [0m[7;93mwork[27m[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[mx1[0m[0m [0m[31m[31m→[31m[0m[0m [0m[mrepH[0m[0m [0m[32ma[0m[0m [0m[31m([0m[0m[0m[7;93mf[27m[0m[0m [0m[31m([0m[0m[0m[31m[31mλ[31m[0m[0m [0m[mx2[0m[0m [0m[31m[31m→[31m[0m[0m [0m[mabsH[0m[0m [0m[32ma[0m[0m [0m[31m([0m[0m[0m[7;93mwork[27m[0m[0m [0m[0m[mx2[0m[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m [0m[0m[mx1[0m[0m[0m[0m[31m)[0m[0m
+repH (:) (Not Proven)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[mx[0m[0m [0m[mxs[0m[0m[0m[31m.[0m[0m
+  [0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mx[0m[0m[0m [0m[0m[mxs[0m[0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[31m([0m[0m[0m[m.[0m[0m[0m[31m)[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mx[0m[0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mxs[0m[0m[0m[0m[31m)[0m[0m
+repH ++ (Not Proven)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[mxs[0m[0m [0m[mys[0m[0m[0m[31m.[0m[0m
+  [0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[31m([0m[0m[0m[m++[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mxs[0m[0m[0m [0m[0m[mys[0m[0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[31m([0m[0m[0m[m.[0m[0m[0m[31m)[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[31m([0m[0m[0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mxs[0m[0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mys[0m[0m[0m[0m[31m)[0m[0m
+repH [] (Not Proven)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m[0m[31m.[0m[0m [0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[m[][0m[0m [0m[0m[32ma[0m[0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[mid[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m[0m

--- a/tests/golden-ghc-7.11/concatVanishes_QSort_hs_QSort_hss.ref
+++ b/tests/golden-ghc-7.11/concatVanishes_QSort_hs_QSort_hss.ref
@@ -1,0 +1,72 @@
+===================== Welcome to HERMIT ======================
+HERMIT is a toolkit for the interactive transformation of GHC
+core language programs. Documentation on HERMIT can be found
+on the HERMIT web page at:
+http://www.ittc.ku.edu/csdl/fpg/software/hermit.html
+
+You have just loaded the interactive shell. To exit, type 
+"abort" or "resume" to abort or resume GHC compilation.
+
+Type "help" for instructions on how to list or search the
+available HERMIT commands.
+
+To get started, you could try the following:
+  - type "binding-of 'foo", where "foo" is a function
+    defined in the module;
+  - type "set-pp-type Show" to display full type information;
+  - type "info" for more information about the current node;
+  - to descend into a child node, type the name of the child
+    ("info" includes a list of children of the current node);
+  - to ascend, use the "up" command;
+  - type "log" to display an activity log.
+==============================================================
+
+[0m[1;34mrec[22m[0m[0m [0m[mqsort[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[31m.[0m[0m [0m[32mOrd[0m[0m [0m[0m[32ma[0m[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m
+    [0m[mqsort[0m[0m [0m[31m=[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[32ma[0m[0m [0m[m$dOrd[0m[0m [0m[31m[31m→[31m[0m[0m
+      [0m[1;34mlet[22m[0m[0m [0m[1;34mrec[22m[0m[0m [0m[mwork[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m
+              [0m[mwork[0m[0m [0m[31m=[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[mx1[0m[0m [0m[macc[0m[0m [0m[31m[31m→[31m[0m[0m
+                [0m[1;34mcase[22m[0m[0m [0m[0m[mx1[0m[0m[0m [0m[1;34mof[22m[0m[0m [0m[mwild[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m
+                  [0m[m[][0m[0m [0m[31m[31m→[31m[0m[0m [0m[0m[macc[0m[0m[0m
+                  [0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[ma[0m[0m [0m[mas[0m[0m [0m[31m[31m→[31m[0m[0m
+                    [0m[1;34mlet[22m[0m[0m [0m[mds[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32m([0m[0m[0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m[0m[32m,[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m[0m[32m)[0m[0m
+                        [0m[mds[0m[0m [0m[31m=[0m[0m [0m[mpartition[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[31m[31mλ[31m[0m[0m [0m[mds[0m[0m [0m[31m[31m→[31m[0m[0m [0m[31m([0m[0m[0m[m<[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[m$dOrd[0m[0m[0m [0m[0m[mds[0m[0m[0m [0m[0m[ma[0m[0m[0m[0m[31m)[0m[0m [0m[0m[mas[0m[0m[0m
+                    [0m[1;34min[22m[0m[0m [0m[1;34mcase[22m[0m[0m [0m[0m[mds[0m[0m[0m [0m[1;34mof[22m[0m[0m [0m[mwild[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m
+                         [0m[m(,)[0m[0m [0m[mbs[0m[0m [0m[mcs[0m[0m [0m[31m[31m→[31m[0m[0m
+                           [0m[0m[mwork[0m[0m[0m [0m[0m[mbs[0m[0m[0m
+                                [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[ma[0m[0m[0m
+                                     [0m[31m([0m[0m[0m[1;34mcase[22m[0m[0m [0m[0m[mds[0m[0m[0m [0m[1;34mof[22m[0m[0m [0m[mwild[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m
+                                        [0m[m(,)[0m[0m [0m[mbs[0m[0m [0m[mcs[0m[0m [0m[31m[31m→[31m[0m[0m [0m[0m[mwork[0m[0m[0m [0m[0m[mcs[0m[0m[0m [0m[0m[macc[0m[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m
+      [0m[1;34min[22m[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[mx0[0m[0m [0m[31m[31m→[31m[0m[0m [0m[0m[mwork[0m[0m[0m [0m[0m[mx0[0m[0m[0m [0m[31m([0m[0m[0m[m[][0m[0m [0m[0m[32ma[0m[0m[0m[0m[31m)[0m[0m
+[0m[m$dShow[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32mShow[0m[0m [0m[32m[[0m[0m[0m[32mInteger[0m[0m[0m[32m][0m[0m
+[0m[m$dShow[0m[0m [0m[31m=[0m[0m [0m[m$fShow[][0m[0m [0m[32mInteger[0m[0m [0m[m$fShowInteger[0m[0m
+[0m[mmain[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32mIO[0m[0m [0m[32m([0m[0m[0m[32m)[0m[0m
+[0m[mmain[0m[0m [0m[31m=[0m[0m
+  [0m[mprint[0m[0m [0m[32m[[0m[0m[0m[32mInteger[0m[0m[0m[32m][0m[0m [0m[0m[m$dShow[0m[0m[0m
+        [0m[31m([0m[0m[0m[0m[mqsort[0m[0m[0m [0m[32mInteger[0m[0m [0m[m$fOrdInteger[0m[0m
+               [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[32mInteger[0m[0m [0m8[0m
+                    [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[32mInteger[0m[0m [0m3[0m
+                         [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[32mInteger[0m[0m [0m5[0m
+                              [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[32mInteger[0m[0m [0m7[0m
+                                   [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[32mInteger[0m[0m [0m2[0m
+                                        [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[32mInteger[0m[0m [0m9[0m
+                                             [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[32mInteger[0m[0m [0m4[0m
+                                                  [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[32mInteger[0m[0m [0m6[0m
+                                                       [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[32mInteger[0m[0m [0m3[0m
+                                                            [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[32mInteger[0m[0m [0m2[0m
+                                                                 [0m[31m([0m[0m[0m[m[][0m[0m [0m[32mInteger[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m
+[0m[mmain[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32mIO[0m[0m [0m[32m([0m[0m[0m[32m)[0m[0m
+[0m[mmain[0m[0m [0m[31m=[0m[0m [0m[mrunMainIO[0m[0m [0m[32m([0m[0m[0m[32m)[0m[0m [0m[0m[mmain[0m[0m[0m[0m
+++ [] (Not Proven)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[mxs[0m[0m[0m[31m.[0m[0m [0m[31m([0m[0m[0m[m++[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mxs[0m[0m[0m [0m[31m([0m[0m[0m[m[][0m[0m [0m[0m[32ma[0m[0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[0m[mxs[0m[0m[0m
+++ strict (Not Proven)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m[0m[31m.[0m[0m [0m[31m([0m[0m[0m[m++[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[mundefined[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[mundefined[0m[0m [0m[31m([0m[0m[0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m[0m[31m)[0m[0m
+recursive-definition-of-work-for-use-by-ww-fusion (Proven)
+  [0m[7;93mwork[27m[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[mx1[0m[0m [0m[31m[31m→[31m[0m[0m [0m[mrepH[0m[0m [0m[32ma[0m[0m [0m[31m([0m[0m[0m[7;93mf[27m[0m[0m [0m[31m([0m[0m[0m[31m[31mλ[31m[0m[0m [0m[mx2[0m[0m [0m[31m[31m→[31m[0m[0m [0m[mabsH[0m[0m [0m[32ma[0m[0m [0m[31m([0m[0m[0m[7;93mwork[27m[0m[0m [0m[0m[mx2[0m[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m [0m[0m[mx1[0m[0m[0m[0m[31m)[0m[0m
+repH (:) (Not Proven)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[mx[0m[0m [0m[mxs[0m[0m[0m[31m.[0m[0m
+  [0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mx[0m[0m[0m [0m[0m[mxs[0m[0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[31m([0m[0m[0m[m.[0m[0m[0m[31m)[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mx[0m[0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mxs[0m[0m[0m[0m[31m)[0m[0m
+repH ++ (Not Proven)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[mxs[0m[0m [0m[mys[0m[0m[0m[31m.[0m[0m
+  [0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[31m([0m[0m[0m[m++[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mxs[0m[0m[0m [0m[0m[mys[0m[0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[31m([0m[0m[0m[m.[0m[0m[0m[31m)[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[31m([0m[0m[0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mxs[0m[0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mys[0m[0m[0m[0m[31m)[0m[0m
+repH [] (Not Proven)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m[0m[31m.[0m[0m [0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[m[][0m[0m [0m[0m[32ma[0m[0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[mid[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m[0m

--- a/tests/golden-ghc-7.11/concatVanishes_Rev_hs_Rev_hss.ref
+++ b/tests/golden-ghc-7.11/concatVanishes_Rev_hs_Rev_hss.ref
@@ -1,0 +1,52 @@
+===================== Welcome to HERMIT ======================
+HERMIT is a toolkit for the interactive transformation of GHC
+core language programs. Documentation on HERMIT can be found
+on the HERMIT web page at:
+http://www.ittc.ku.edu/csdl/fpg/software/hermit.html
+
+You have just loaded the interactive shell. To exit, type 
+"abort" or "resume" to abort or resume GHC compilation.
+
+Type "help" for instructions on how to list or search the
+available HERMIT commands.
+
+To get started, you could try the following:
+  - type "binding-of 'foo", where "foo" is a function
+    defined in the module;
+  - type "set-pp-type Show" to display full type information;
+  - type "info" for more information about the current node;
+  - to descend into a child node, type the name of the child
+    ("info" includes a list of children of the current node);
+  - to ascend, use the "up" command;
+  - type "log" to display an activity log.
+==============================================================
+
+[0m[1;34mrec[22m[0m[0m [0m[mrev[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[31m.[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m
+    [0m[mrev[0m[0m [0m[31m=[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[32ma[0m[0m [0m[31m[31m→[31m[0m[0m
+      [0m[1;34mlet[22m[0m[0m [0m[1;34mrec[22m[0m[0m [0m[mwork[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m
+              [0m[mwork[0m[0m [0m[31m=[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[mx1[0m[0m [0m[macc[0m[0m [0m[31m[31m→[31m[0m[0m
+                [0m[1;34mcase[22m[0m[0m [0m[0m[mx1[0m[0m[0m [0m[1;34mof[22m[0m[0m [0m[mwild[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m
+                  [0m[m[][0m[0m [0m[31m[31m→[31m[0m[0m [0m[0m[macc[0m[0m[0m
+                  [0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[my[0m[0m [0m[mys[0m[0m [0m[31m[31m→[31m[0m[0m [0m[0m[mwork[0m[0m[0m [0m[0m[mys[0m[0m[0m [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[my[0m[0m[0m [0m[0m[macc[0m[0m[0m[0m[31m)[0m[0m
+      [0m[1;34min[22m[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[mx0[0m[0m [0m[31m[31m→[31m[0m[0m [0m[0m[mwork[0m[0m[0m [0m[0m[mx0[0m[0m[0m [0m[31m([0m[0m[0m[m[][0m[0m [0m[0m[32ma[0m[0m[0m[0m[31m)[0m[0m
+[0m[mmain[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32mIO[0m[0m [0m[32m([0m[0m[0m[32m)[0m[0m
+[0m[mmain[0m[0m [0m[31m=[0m[0m
+  [0m[31m([0m[0m[0m[m$[0m[0m[0m[31m)[0m[0m [0m[32m[[0m[0m[0m[32mInteger[0m[0m[0m[32m][0m[0m [0m[31m([0m[0m[0m[32mIO[0m[0m [0m[32m([0m[0m[0m[32m)[0m[0m[0m[31m)[0m[0m
+      [0m[31m([0m[0m[0m[mprint[0m[0m [0m[32m[[0m[0m[0m[32mInteger[0m[0m[0m[32m][0m[0m [0m[31m([0m[0m[0m[m$fShow[][0m[0m [0m[32mInteger[0m[0m [0m[m$fShowInteger[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m
+      [0m[31m([0m[0m[0m[0m[mrev[0m[0m[0m [0m[32mInteger[0m[0m [0m[31m([0m[0m[0m[menumFromTo[0m[0m [0m[32mInteger[0m[0m [0m[m$fEnumInteger[0m[0m [0m1[0m [0m10[0m[0m[31m)[0m[0m[0m[31m)[0m[0m
+[0m[mmain[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32mIO[0m[0m [0m[32m([0m[0m[0m[32m)[0m[0m
+[0m[mmain[0m[0m [0m[31m=[0m[0m [0m[mrunMainIO[0m[0m [0m[32m([0m[0m[0m[32m)[0m[0m [0m[0m[mmain[0m[0m[0m[0m
+++ [] (Not Proven)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[mxs[0m[0m[0m[31m.[0m[0m [0m[31m([0m[0m[0m[m++[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mxs[0m[0m[0m [0m[31m([0m[0m[0m[m[][0m[0m [0m[0m[32ma[0m[0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[0m[mxs[0m[0m[0m
+++ strict (Not Proven)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m[0m[31m.[0m[0m [0m[31m([0m[0m[0m[m++[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[mundefined[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[mundefined[0m[0m [0m[31m([0m[0m[0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m[0m[31m)[0m[0m
+recursive-definition-of-work-for-use-by-ww-fusion (Proven)
+  [0m[7;93mwork[27m[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[mx1[0m[0m [0m[31m[31m→[31m[0m[0m [0m[mrepH[0m[0m [0m[32ma[0m[0m [0m[31m([0m[0m[0m[7;93mf[27m[0m[0m [0m[31m([0m[0m[0m[31m[31mλ[31m[0m[0m [0m[mx2[0m[0m [0m[31m[31m→[31m[0m[0m [0m[mabsH[0m[0m [0m[32ma[0m[0m [0m[31m([0m[0m[0m[7;93mwork[27m[0m[0m [0m[0m[mx2[0m[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m [0m[0m[mx1[0m[0m[0m[0m[31m)[0m[0m
+repH (:) (Not Proven)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[mx[0m[0m [0m[mxs[0m[0m[0m[31m.[0m[0m
+  [0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mx[0m[0m[0m [0m[0m[mxs[0m[0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[31m([0m[0m[0m[m.[0m[0m[0m[31m)[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mx[0m[0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mxs[0m[0m[0m[0m[31m)[0m[0m
+repH ++ (Not Proven)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[mxs[0m[0m [0m[mys[0m[0m[0m[31m.[0m[0m
+  [0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[31m([0m[0m[0m[m++[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mxs[0m[0m[0m [0m[0m[mys[0m[0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[31m([0m[0m[0m[m.[0m[0m[0m[31m)[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[31m([0m[0m[0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mxs[0m[0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mys[0m[0m[0m[0m[31m)[0m[0m
+repH [] (Not Proven)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m[0m[31m.[0m[0m [0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[m[][0m[0m [0m[0m[32ma[0m[0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[mid[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m[0m

--- a/tests/golden-ghc-7.11/evaluation_Eval_hs_Eval_hss.ref
+++ b/tests/golden-ghc-7.11/evaluation_Eval_hs_Eval_hss.ref
@@ -1,0 +1,49 @@
+===================== Welcome to HERMIT ======================
+HERMIT is a toolkit for the interactive transformation of GHC
+core language programs. Documentation on HERMIT can be found
+on the HERMIT web page at:
+http://www.ittc.ku.edu/csdl/fpg/software/hermit.html
+
+You have just loaded the interactive shell. To exit, type 
+"abort" or "resume" to abort or resume GHC compilation.
+
+Type "help" for instructions on how to list or search the
+available HERMIT commands.
+
+To get started, you could try the following:
+  - type "binding-of 'foo", where "foo" is a function
+    defined in the module;
+  - type "set-pp-type Show" to display full type information;
+  - type "info" for more information about the current node;
+  - to descend into a child node, type the name of the child
+    ("info" includes a list of children of the current node);
+  - to ascend, use the "up" command;
+  - type "log" to display an activity log.
+==============================================================
+
+[0m[1;34mrec[22m[0m[0m [0m[mrep[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32mMint[0m[0m [0m[32m[32m→[32m[0m[0m [0m[31m([0m[0m[0m[32mInt[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32mMint[0m[0m[0m[31m)[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32mMint[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32mMint[0m[0m
+    [0m[mrep[0m[0m [0m[31m=[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[mmn[0m[0m [0m[ms[0m[0m [0m[mf[0m[0m [0m[31m[31m→[31m[0m[0m
+      [0m[1;34mcase[22m[0m[0m [0m[0m[mmn[0m[0m[0m [0m[1;34mof[22m[0m[0m [0m[mwild[0m[0m [0m[32mMint[0m[0m
+        [0m[mNothing[0m[0m [0m[31m[31m→[31m[0m[0m [0m[0m[mf[0m[0m[0m
+        [0m[mJust[0m[0m [0m[mn[0m[0m [0m[31m[31m→[31m[0m[0m [0m[0m[ms[0m[0m[0m [0m[0m[mn[0m[0m[0m
+    [0m[mabs[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[31m([0m[0m[0m[31m([0m[0m[0m[32mInt[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32mMint[0m[0m[0m[31m)[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32mMint[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32mMint[0m[0m[0m[31m)[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32mMint[0m[0m
+    [0m[mabs[0m[0m [0m[31m=[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[mh[0m[0m [0m[31m[31m→[31m[0m[0m [0m[0m[mh[0m[0m[0m [0m[31m([0m[0m[0m[mJust[0m[0m [0m[32mInt[0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[mNothing[0m[0m [0m[32mInt[0m[0m[0m[31m)[0m[0m
+    [0m[m$dShow[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32mShow[0m[0m [0m[31m([0m[0m[0m[32mMaybe[0m[0m [0m[32mInt[0m[0m[0m[31m)[0m[0m
+    [0m[m$dShow[0m[0m [0m[31m=[0m[0m [0m[m$fShowMaybe[0m[0m [0m[32mInt[0m[0m [0m[m$fShowInt[0m[0m
+    [0m[meval[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32mExpr[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32mMint[0m[0m
+    [0m[meval[0m[0m [0m[31m=[0m[0m
+      [0m[1;34mlet[22m[0m[0m [0m[1;34mrec[22m[0m[0m [0m[mwork[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32mExpr[0m[0m [0m[32m[32m→[32m[0m[0m [0m[31m([0m[0m[0m[32mInt[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32mMint[0m[0m[0m[31m)[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32mMint[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32mMint[0m[0m
+              [0m[mwork[0m[0m [0m[31m=[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[me[0m[0m [0m[ms[0m[0m [0m[mf[0m[0m [0m[31m[31m→[31m[0m[0m
+                [0m[1;34mcase[22m[0m[0m [0m[0m[me[0m[0m[0m [0m[1;34mof[22m[0m[0m [0m[mwild[0m[0m [0m[32mMint[0m[0m
+                  [0m[mVal[0m[0m [0m[mn[0m[0m [0m[31m[31m→[31m[0m[0m [0m[0m[ms[0m[0m[0m [0m[0m[mn[0m[0m[0m
+                  [0m[mAdd[0m[0m [0m[mx[0m[0m [0m[my[0m[0m [0m[31m[31m→[31m[0m[0m
+                    [0m[0m[mwork[0m[0m[0m [0m[0m[mx[0m[0m[0m [0m[31m([0m[0m[0m[31m[31mλ[31m[0m[0m [0m[mm[0m[0m [0m[31m[31m→[31m[0m[0m [0m[0m[mwork[0m[0m[0m [0m[0m[my[0m[0m[0m [0m[31m([0m[0m[0m[31m[31mλ[31m[0m[0m [0m[mn[0m[0m [0m[31m[31m→[31m[0m[0m [0m[0m[ms[0m[0m[0m [0m[31m([0m[0m[0m[31m([0m[0m[0m[m+[0m[0m[0m[31m)[0m[0m [0m[32mInt[0m[0m [0m[m$fNumInt[0m[0m [0m[0m[mm[0m[0m[0m [0m[0m[mn[0m[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m [0m[0m[mf[0m[0m[0m[0m[31m)[0m[0m [0m[0m[mf[0m[0m[0m
+                  [0m[mThrow[0m[0m [0m[31m[31m→[31m[0m[0m [0m[0m[mf[0m[0m[0m
+                  [0m[mCatch[0m[0m [0m[mx[0m[0m [0m[my[0m[0m [0m[31m[31m→[31m[0m[0m [0m[0m[mwork[0m[0m[0m [0m[0m[mx[0m[0m[0m [0m[0m[ms[0m[0m[0m [0m[31m([0m[0m[0m[0m[mwork[0m[0m[0m [0m[0m[my[0m[0m[0m [0m[0m[ms[0m[0m[0m [0m[0m[mf[0m[0m[0m[0m[31m)[0m[0m
+      [0m[1;34min[22m[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[me[0m[0m [0m[31m[31m→[31m[0m[0m [0m[0m[mwork[0m[0m[0m [0m[0m[me[0m[0m[0m [0m[31m([0m[0m[0m[mJust[0m[0m [0m[32mInt[0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[mNothing[0m[0m [0m[32mInt[0m[0m[0m[31m)[0m[0m
+    [0m[mmain[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32mIO[0m[0m [0m[32m([0m[0m[0m[32m)[0m[0m
+    [0m[mmain[0m[0m [0m[31m=[0m[0m [0m[mprint[0m[0m [0m[32mMint[0m[0m [0m[0m[m$dShow[0m[0m[0m [0m[31m([0m[0m[0m[31m([0m[0m[0m[m$[0m[0m[0m[31m)[0m[0m [0m[32mExpr[0m[0m [0m[32mMint[0m[0m [0m[0m[meval[0m[0m[0m [0m[31m([0m[0m[0m[mVal[0m[0m [0m[31m([0m[0m[0m[mI#[0m[0m [0m5#[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m
+    [0m[mmain[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32mIO[0m[0m [0m[32m([0m[0m[0m[32m)[0m[0m
+    [0m[mmain[0m[0m [0m[31m=[0m[0m [0m[mrunMainIO[0m[0m [0m[32m([0m[0m[0m[32m)[0m[0m [0m[0m[mmain[0m[0m[0m[0m
+recursive-definition-of-work-for-use-by-ww-fusion (Proven)
+  [0m[7;93mwork[27m[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[mx1[0m[0m [0m[31m[31m→[31m[0m[0m [0m[7;93mrep[27m[0m[0m [0m[31m([0m[0m[0m[7;93mf[27m[0m[0m [0m[31m([0m[0m[0m[31m[31mλ[31m[0m[0m [0m[mx2[0m[0m [0m[31m[31m→[31m[0m[0m [0m[7;93mabs[27m[0m[0m [0m[31m([0m[0m[0m[7;93mwork[27m[0m[0m [0m[0m[mx2[0m[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m [0m[0m[mx1[0m[0m[0m[0m[31m)[0m[0m[0m

--- a/tests/golden-ghc-7.11/fib-tuple_Fib_hs_Fib_hss.ref
+++ b/tests/golden-ghc-7.11/fib-tuple_Fib_hs_Fib_hss.ref
@@ -1,0 +1,70 @@
+===================== Welcome to HERMIT ======================
+HERMIT is a toolkit for the interactive transformation of GHC
+core language programs. Documentation on HERMIT can be found
+on the HERMIT web page at:
+http://www.ittc.ku.edu/csdl/fpg/software/hermit.html
+
+You have just loaded the interactive shell. To exit, type 
+"abort" or "resume" to abort or resume GHC compilation.
+
+Type "help" for instructions on how to list or search the
+available HERMIT commands.
+
+To get started, you could try the following:
+  - type "binding-of 'foo", where "foo" is a function
+    defined in the module;
+  - type "set-pp-type Show" to display full type information;
+  - type "info" for more information about the current node;
+  - to descend into a child node, type the name of the child
+    ("info" includes a list of children of the current node);
+  - to ascend, use the "up" command;
+  - type "log" to display an activity log.
+==============================================================
+
+[0m[1;34mrec[22m[0m[0m [0m[munwrap[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[31m([0m[0m[0m[32mNat[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32mNat[0m[0m[0m[31m)[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32mNat[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m([0m[0m[0m[32mNat[0m[0m[0m[32m,[0m[0m [0m[32mNat[0m[0m[0m[32m)[0m[0m
+    [0m[munwrap[0m[0m [0m[31m=[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[mh[0m[0m [0m[mn[0m[0m [0m[31m[31m→[31m[0m[0m [0m[m(,)[0m[0m [0m[32mNat[0m[0m [0m[32mNat[0m[0m [0m[31m([0m[0m[0m[0m[mh[0m[0m[0m [0m[0m[mn[0m[0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[0m[mh[0m[0m[0m [0m[31m([0m[0m[0m[mS[0m[0m [0m[0m[mn[0m[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m
+    [0m[mwrap[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[31m([0m[0m[0m[32mNat[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m([0m[0m[0m[32mNat[0m[0m[0m[32m,[0m[0m [0m[32mNat[0m[0m[0m[32m)[0m[0m[0m[31m)[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32mNat[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32mNat[0m[0m
+    [0m[mwrap[0m[0m [0m[31m=[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[mh[0m[0m [0m[mn[0m[0m [0m[31m[31m→[31m[0m[0m [0m[mfst[0m[0m [0m[32mNat[0m[0m [0m[32mNat[0m[0m [0m[31m([0m[0m[0m[0m[mh[0m[0m[0m [0m[0m[mn[0m[0m[0m[0m[31m)[0m[0m
+    [0m[31m([0m[0m[0m[m+[0m[0m[0m[31m)[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32mNat[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32mNat[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32mNat[0m[0m
+    [0m[31m([0m[0m[0m[m+[0m[0m[0m[31m)[0m[0m [0m[31m=[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[mds[0m[0m [0m[mn[0m[0m [0m[31m[31m→[31m[0m[0m
+      [0m[1;34mcase[22m[0m[0m [0m[0m[mds[0m[0m[0m [0m[1;34mof[22m[0m[0m [0m[mwild[0m[0m [0m[32mNat[0m[0m
+        [0m[mZ[0m[0m [0m[31m[31m→[31m[0m[0m [0m[0m[mn[0m[0m[0m
+        [0m[mS[0m[0m [0m[mn'[0m[0m [0m[31m[31m→[31m[0m[0m [0m[mS[0m[0m [0m[31m([0m[0m[0m[0m[31m([0m[0m[0m[m+[0m[0m[0m[31m)[0m[0m[0m [0m[0m[mn'[0m[0m[0m [0m[0m[mn[0m[0m[0m[0m[31m)[0m[0m
+    [0m[mfib[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32mNat[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32mNat[0m[0m
+    [0m[mfib[0m[0m [0m[31m=[0m[0m
+      [0m[1;34mlet[22m[0m[0m [0m[1;34mrec[22m[0m[0m [0m[mwork[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32mNat[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m([0m[0m[0m[32mNat[0m[0m[0m[32m,[0m[0m [0m[32mNat[0m[0m[0m[32m)[0m[0m
+              [0m[mwork[0m[0m [0m[31m=[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[mn[0m[0m [0m[31m[31m→[31m[0m[0m
+                [0m[1;34mcase[22m[0m[0m [0m[0m[mn[0m[0m[0m [0m[1;34mof[22m[0m[0m [0m[mw[0m[0m [0m[32m([0m[0m[0m[32mNat[0m[0m[0m[32m,[0m[0m [0m[32mNat[0m[0m[0m[32m)[0m[0m
+                  [0m[mZ[0m[0m [0m[31m[31m→[31m[0m[0m [0m[m(,)[0m[0m [0m[32mNat[0m[0m [0m[32mNat[0m[0m [0m[mZ[0m[0m [0m[31m([0m[0m[0m[mS[0m[0m [0m[mZ[0m[0m[0m[31m)[0m[0m
+                  [0m[mS[0m[0m [0m[ma[0m[0m [0m[31m[31m→[31m[0m[0m
+                    [0m[1;34mcase[22m[0m[0m [0m[0m[mwork[0m[0m[0m [0m[0m[ma[0m[0m[0m [0m[1;34mof[22m[0m[0m [0m[mxy[0m[0m [0m[32m([0m[0m[0m[32mNat[0m[0m[0m[32m,[0m[0m [0m[32mNat[0m[0m[0m[32m)[0m[0m
+                      [0m[m(,)[0m[0m [0m[mx[0m[0m [0m[my[0m[0m [0m[31m[31m→[31m[0m[0m [0m[m(,)[0m[0m [0m[32mNat[0m[0m [0m[32mNat[0m[0m [0m[0m[my[0m[0m[0m [0m[31m([0m[0m[0m[0m[31m([0m[0m[0m[m+[0m[0m[0m[31m)[0m[0m[0m [0m[0m[my[0m[0m[0m [0m[0m[mx[0m[0m[0m[0m[31m)[0m[0m
+      [0m[1;34min[22m[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[mn[0m[0m [0m[31m[31m→[31m[0m[0m [0m[mfst[0m[0m [0m[32mNat[0m[0m [0m[32mNat[0m[0m [0m[31m([0m[0m[0m[0m[mwork[0m[0m[0m [0m[0m[mn[0m[0m[0m[0m[31m)[0m[0m
+    [0m[mfromInt[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32mInt[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32mNat[0m[0m
+    [0m[mfromInt[0m[0m [0m[31m=[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[mds[0m[0m [0m[31m[31m→[31m[0m[0m
+      [0m[1;34mcase[22m[0m[0m [0m[0m[mds[0m[0m[0m [0m[1;34mof[22m[0m[0m [0m[mwild[0m[0m [0m[32mNat[0m[0m
+        [0m[mI#[0m[0m [0m[mds[0m[0m [0m[31m[31m→[31m[0m[0m
+          [0m[1;34mcase[22m[0m[0m [0m[0m[mds[0m[0m[0m [0m[1;34mof[22m[0m[0m [0m[mds[0m[0m [0m[32mNat[0m[0m
+            [0m[31m_[0m[0m [0m[31m[31m→[31m[0m[0m
+              [0m[31m([0m[0m[0m[31m[31mλ[31m[0m[0m [0m[mds[0m[0m [0m[31m[31m→[31m[0m[0m
+                 [0m[1;34mcase[22m[0m[0m [0m[31m([0m[0m[0m[m<[0m[0m[0m[31m)[0m[0m [0m[32mInt[0m[0m [0m[m$fOrdInt[0m[0m [0m[0m[mds[0m[0m[0m [0m[31m([0m[0m[0m[mI#[0m[0m [0m0#[0m[0m[31m)[0m[0m [0m[1;34mof[22m[0m[0m [0m[mwild[0m[0m [0m[32mNat[0m[0m
+                   [0m[mFalse[0m[0m [0m[31m[31m→[31m[0m[0m
+                     [0m[31m([0m[0m[0m[31m[31mλ[31m[0m[0m [0m[mds[0m[0m [0m[31m[31m→[31m[0m[0m [0m[mS[0m[0m [0m[31m([0m[0m[0m[0m[mfromInt[0m[0m[0m [0m[31m([0m[0m[0m[31m([0m[0m[0m[m-[0m[0m[0m[31m)[0m[0m [0m[32mInt[0m[0m [0m[m$fNumInt[0m[0m [0m[0m[mds[0m[0m[0m [0m[31m([0m[0m[0m[mI#[0m[0m [0m1#[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m [0m[mvoid#[0m[0m
+                   [0m[mTrue[0m[0m [0m[31m[31m→[31m[0m[0m
+                     [0m[merror[0m[0m [0m[32mNat[0m[0m [0m[31m([0m[0m[0m[munpackCString#[0m[0m [0m[31m([0m[0m[0m"fromInt negative"#[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m [0m[mvoid#[0m[0m
+            [0m0#[0m [0m[31m[31m→[31m[0m[0m [0m[mZ[0m[0m
+    [0m[mtoInt[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32mNat[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32mInt[0m[0m
+    [0m[mtoInt[0m[0m [0m[31m=[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[mds[0m[0m [0m[31m[31m→[31m[0m[0m
+      [0m[1;34mcase[22m[0m[0m [0m[0m[mds[0m[0m[0m [0m[1;34mof[22m[0m[0m [0m[mwild[0m[0m [0m[32mInt[0m[0m
+        [0m[mZ[0m[0m [0m[31m[31m→[31m[0m[0m [0m[mI#[0m[0m [0m0#[0m
+        [0m[mS[0m[0m [0m[mn[0m[0m [0m[31m[31m→[31m[0m[0m [0m[msucc[0m[0m [0m[32mInt[0m[0m [0m[m$fEnumInt[0m[0m [0m[31m([0m[0m[0m[0m[mtoInt[0m[0m[0m [0m[0m[mn[0m[0m[0m[0m[31m)[0m[0m
+    [0m[mmain[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32mIO[0m[0m [0m[32m([0m[0m[0m[32m)[0m[0m
+    [0m[mmain[0m[0m [0m[31m=[0m[0m
+      [0m[31m([0m[0m[0m[m$[0m[0m[0m[31m)[0m[0m [0m[32mInt[0m[0m [0m[31m([0m[0m[0m[32mIO[0m[0m [0m[32m([0m[0m[0m[32m)[0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[mprint[0m[0m [0m[32mInt[0m[0m [0m[m$fShowInt[0m[0m[0m[31m)[0m[0m
+          [0m[31m([0m[0m[0m[31m([0m[0m[0m[m$[0m[0m[0m[31m)[0m[0m [0m[32mNat[0m[0m [0m[32mInt[0m[0m [0m[0m[mtoInt[0m[0m[0m [0m[31m([0m[0m[0m[0m[mfib[0m[0m[0m [0m[31m([0m[0m[0m[0m[mfromInt[0m[0m[0m [0m[31m([0m[0m[0m[mI#[0m[0m [0m30#[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m
+    [0m[mmain[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32mIO[0m[0m [0m[32m([0m[0m[0m[32m)[0m[0m
+    [0m[mmain[0m[0m [0m[31m=[0m[0m [0m[mrunMainIO[0m[0m [0m[32m([0m[0m[0m[32m)[0m[0m [0m[0m[mmain[0m[0m[0m[0m
+recursive-definition-of-work-for-use-by-ww-fusion (Proven)
+  [0m[7;93mwork[27m[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[7;93munwrap[27m[0m[0m [0m[31m([0m[0m[0m[7;93mf[27m[0m[0m [0m[31m([0m[0m[0m[7;93mwrap[27m[0m[0m [0m[7;93mwork[27m[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m
+remembered-origwork (Proven)
+  [0m[7;93mwork[27m[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[7;93munwrap[27m[0m[0m [0m[31m([0m[0m[0m[7;93mf[27m[0m[0m [0m[31m([0m[0m[0m[7;93mwrap[27m[0m[0m [0m[7;93mwork[27m[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m

--- a/tests/golden-ghc-7.11/flatten_Flatten_hs_Flatten_hec.ref
+++ b/tests/golden-ghc-7.11/flatten_Flatten_hs_Flatten_hec.ref
@@ -1,0 +1,54 @@
+===================== Welcome to HERMIT ======================
+HERMIT is a toolkit for the interactive transformation of GHC
+core language programs. Documentation on HERMIT can be found
+on the HERMIT web page at:
+http://www.ittc.ku.edu/csdl/fpg/software/hermit.html
+
+You have just loaded the interactive shell. To exit, type 
+"abort" or "resume" to abort or resume GHC compilation.
+
+Type "help" for instructions on how to list or search the
+available HERMIT commands.
+
+To get started, you could try the following:
+  - type "binding-of 'foo", where "foo" is a function
+    defined in the module;
+  - type "set-pp-type Show" to display full type information;
+  - type "info" for more information about the current node;
+  - to descend into a child node, type the name of the child
+    ("info" includes a list of children of the current node);
+  - to ascend, use the "up" command;
+  - type "log" to display an activity log.
+==============================================================
+
+[0m[1;34mrec[22m[0m[0m [0m[mflatten[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[31m.[0m[0m [0m[32mTree[0m[0m [0m[0m[32ma[0m[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m
+    [0m[mflatten[0m[0m [0m[31m=[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[32ma[0m[0m [0m[31m[31m→[31m[0m[0m
+      [0m[1;34mlet[22m[0m[0m [0m[1;34mrec[22m[0m[0m [0m[mwork[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32mTree[0m[0m [0m[0m[32ma[0m[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m
+              [0m[mwork[0m[0m [0m[31m=[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[mtree[0m[0m [0m[macc[0m[0m [0m[31m[31m→[31m[0m[0m
+                [0m[1;34mcase[22m[0m[0m [0m[0m[mtree[0m[0m[0m [0m[1;34mof[22m[0m[0m [0m[mwild[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m
+                  [0m[mNode[0m[0m [0m[ml[0m[0m [0m[mr[0m[0m [0m[31m[31m→[31m[0m[0m [0m[0m[mwork[0m[0m[0m [0m[0m[ml[0m[0m[0m [0m[31m([0m[0m[0m[0m[mwork[0m[0m[0m [0m[0m[mr[0m[0m[0m [0m[0m[macc[0m[0m[0m[0m[31m)[0m[0m
+                  [0m[mLeaf[0m[0m [0m[ma[0m[0m [0m[31m[31m→[31m[0m[0m [0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[ma[0m[0m[0m [0m[0m[macc[0m[0m[0m
+      [0m[1;34min[22m[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[mx0[0m[0m [0m[31m[31m→[31m[0m[0m [0m[0m[mwork[0m[0m[0m [0m[0m[mx0[0m[0m[0m [0m[31m([0m[0m[0m[m[][0m[0m [0m[0m[32ma[0m[0m[0m[0m[31m)[0m[0m
+[0m[m$dShow[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32mShow[0m[0m [0m[32m[[0m[0m[0m[32mChar[0m[0m[0m[32m][0m[0m
+[0m[m$dShow[0m[0m [0m[31m=[0m[0m [0m[m$fShow[][0m[0m [0m[32mChar[0m[0m [0m[m$fShowChar[0m[0m
+[0m[mmain[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32mIO[0m[0m [0m[32m([0m[0m[0m[32m)[0m[0m
+[0m[mmain[0m[0m [0m[31m=[0m[0m
+  [0m[mprint[0m[0m [0m[32m[[0m[0m[0m[32mChar[0m[0m[0m[32m][0m[0m [0m[0m[m$dShow[0m[0m[0m
+        [0m[31m([0m[0m[0m[0m[mflatten[0m[0m[0m [0m[32mChar[0m[0m
+                 [0m[31m([0m[0m[0m[mNode[0m[0m [0m[32mChar[0m[0m [0m[31m([0m[0m[0m[mLeaf[0m[0m [0m[32mChar[0m[0m [0m[31m([0m[0m[0m[mC#[0m[0m [0m'h'#[0m[0m[31m)[0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[mLeaf[0m[0m [0m[32mChar[0m[0m [0m[31m([0m[0m[0m[mC#[0m[0m [0m'i'#[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m
+[0m[mmain[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32mIO[0m[0m [0m[32m([0m[0m[0m[32m)[0m[0m
+[0m[mmain[0m[0m [0m[31m=[0m[0m [0m[mrunMainIO[0m[0m [0m[32m([0m[0m[0m[32m)[0m[0m [0m[0m[mmain[0m[0m[0m[0m
+++ [] (Not Proven)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[mxs[0m[0m[0m[31m.[0m[0m [0m[31m([0m[0m[0m[m++[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mxs[0m[0m[0m [0m[31m([0m[0m[0m[m[][0m[0m [0m[0m[32ma[0m[0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[0m[mxs[0m[0m[0m
+++ strict (Not Proven)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m[0m[31m.[0m[0m [0m[31m([0m[0m[0m[m++[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[mundefined[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[mundefined[0m[0m [0m[31m([0m[0m[0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m[0m[31m)[0m[0m
+recursive-definition-of-work-for-use-by-ww-fusion (Proven)
+  [0m[7;93mwork[27m[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[mx1[0m[0m [0m[31m[31m→[31m[0m[0m [0m[mrepH[0m[0m [0m[32ma[0m[0m [0m[31m([0m[0m[0m[7;93mf[27m[0m[0m [0m[31m([0m[0m[0m[31m[31mλ[31m[0m[0m [0m[mx2[0m[0m [0m[31m[31m→[31m[0m[0m [0m[mabsH[0m[0m [0m[32ma[0m[0m [0m[31m([0m[0m[0m[7;93mwork[27m[0m[0m [0m[0m[mx2[0m[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m [0m[0m[mx1[0m[0m[0m[0m[31m)[0m[0m
+repH (:) (Not Proven)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[mx[0m[0m [0m[mxs[0m[0m[0m[31m.[0m[0m
+  [0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mx[0m[0m[0m [0m[0m[mxs[0m[0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[31m([0m[0m[0m[m.[0m[0m[0m[31m)[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mx[0m[0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mxs[0m[0m[0m[0m[31m)[0m[0m
+repH ++ (Not Proven)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[mxs[0m[0m [0m[mys[0m[0m[0m[31m.[0m[0m
+  [0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[31m([0m[0m[0m[m++[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mxs[0m[0m[0m [0m[0m[mys[0m[0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[31m([0m[0m[0m[m.[0m[0m[0m[31m)[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[31m([0m[0m[0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mxs[0m[0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mys[0m[0m[0m[0m[31m)[0m[0m
+repH [] (Not Proven)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m[0m[31m.[0m[0m [0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[m[][0m[0m [0m[0m[32ma[0m[0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[mid[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m[0m

--- a/tests/golden-ghc-7.11/last_Last_hs_Last_hss.ref
+++ b/tests/golden-ghc-7.11/last_Last_hs_Last_hss.ref
@@ -1,0 +1,47 @@
+===================== Welcome to HERMIT ======================
+HERMIT is a toolkit for the interactive transformation of GHC
+core language programs. Documentation on HERMIT can be found
+on the HERMIT web page at:
+http://www.ittc.ku.edu/csdl/fpg/software/hermit.html
+
+You have just loaded the interactive shell. To exit, type 
+"abort" or "resume" to abort or resume GHC compilation.
+
+Type "help" for instructions on how to list or search the
+available HERMIT commands.
+
+To get started, you could try the following:
+  - type "binding-of 'foo", where "foo" is a function
+    defined in the module;
+  - type "set-pp-type Show" to display full type information;
+  - type "info" for more information about the current node;
+  - to descend into a child node, type the name of the child
+    ("info" includes a list of children of the current node);
+  - to ascend, use the "up" command;
+  - type "log" to display an activity log.
+==============================================================
+
+[0m[1;34mrec[22m[0m[0m [0m[mlast[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[31m.[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[0m[32ma[0m[0m[0m
+    [0m[mlast[0m[0m [0m[31m=[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[32ma[0m[0m [0m[31m[31m→[31m[0m[0m
+      [0m[1;34mlet[22m[0m[0m [0m[1;34mrec[22m[0m[0m [0m[mwork[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[0m[32ma[0m[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[0m[32ma[0m[0m[0m
+              [0m[mwork[0m[0m [0m[31m=[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[ma0[0m[0m [0m[mas[0m[0m [0m[31m[31m→[31m[0m[0m
+                [0m[1;34mcase[22m[0m[0m [0m[0m[mas[0m[0m[0m [0m[1;34mof[22m[0m[0m [0m[mwild[0m[0m [0m[0m[32ma[0m[0m[0m
+                  [0m[m[][0m[0m [0m[31m[31m→[31m[0m[0m [0m[0m[ma0[0m[0m[0m
+                  [0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[ma1[0m[0m [0m[mas0[0m[0m [0m[31m[31m→[31m[0m[0m [0m[0m[mwork[0m[0m[0m [0m[0m[ma1[0m[0m[0m [0m[0m[mas0[0m[0m[0m
+      [0m[1;34min[22m[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[mds[0m[0m [0m[31m[31m→[31m[0m[0m
+           [0m[1;34mcase[22m[0m[0m [0m[0m[mds[0m[0m[0m [0m[1;34mof[22m[0m[0m [0m[mwild[0m[0m [0m[0m[32ma[0m[0m[0m
+             [0m[m[][0m[0m [0m[31m[31m→[31m[0m[0m [0m[mundefined[0m[0m [0m[0m[32ma[0m[0m[0m
+             [0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[ma0[0m[0m [0m[mas[0m[0m [0m[31m[31m→[31m[0m[0m [0m[0m[mwork[0m[0m[0m [0m[0m[ma0[0m[0m[0m [0m[0m[mas[0m[0m[0m
+    [0m[mwrap[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[31m.[0m[0m [0m[31m([0m[0m[0m[0m[32ma[0m[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[0m[32ma[0m[0m[0m[0m[31m)[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[0m[32ma[0m[0m[0m
+    [0m[mwrap[0m[0m [0m[31m=[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[32ma[0m[0m [0m[mf[0m[0m [0m[mds[0m[0m [0m[31m[31m→[31m[0m[0m
+      [0m[1;34mcase[22m[0m[0m [0m[0m[mds[0m[0m[0m [0m[1;34mof[22m[0m[0m [0m[mwild[0m[0m [0m[0m[32ma[0m[0m[0m
+        [0m[m[][0m[0m [0m[31m[31m→[31m[0m[0m [0m[mundefined[0m[0m [0m[0m[32ma[0m[0m[0m
+        [0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[ma[0m[0m [0m[mas[0m[0m [0m[31m[31m→[31m[0m[0m [0m[0m[mf[0m[0m[0m [0m[0m[ma[0m[0m[0m [0m[0m[mas[0m[0m[0m
+    [0m[munwrap[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[31m.[0m[0m [0m[31m([0m[0m[0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[0m[32ma[0m[0m[0m[0m[31m)[0m[0m [0m[32m[32m→[32m[0m[0m [0m[0m[32ma[0m[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[0m[32ma[0m[0m[0m
+    [0m[munwrap[0m[0m [0m[31m=[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[32ma[0m[0m [0m[mf[0m[0m [0m[ma[0m[0m [0m[mas[0m[0m [0m[31m[31m→[31m[0m[0m [0m[0m[mf[0m[0m[0m [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[ma[0m[0m[0m [0m[0m[mas[0m[0m[0m[0m[31m)[0m[0m
+    [0m[mmain[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32mIO[0m[0m [0m[32m([0m[0m[0m[32m)[0m[0m
+    [0m[mmain[0m[0m [0m[31m=[0m[0m [0m[mprint[0m[0m [0m[32mChar[0m[0m [0m[m$fShowChar[0m[0m [0m[31m([0m[0m[0m[0m[mlast[0m[0m[0m [0m[32mChar[0m[0m [0m[31m([0m[0m[0m[munpackCString#[0m[0m [0m"hello"#[0m[0m[31m)[0m[0m[0m[31m)[0m[0m
+    [0m[mmain[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32mIO[0m[0m [0m[32m([0m[0m[0m[32m)[0m[0m
+    [0m[mmain[0m[0m [0m[31m=[0m[0m [0m[mrunMainIO[0m[0m [0m[32m([0m[0m[0m[32m)[0m[0m [0m[0m[mmain[0m[0m[0m[0m
+recursive-definition-of-work-for-use-by-ww-fusion (Proven)
+  [0m[7;93mwork[27m[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[7;93munwrap[27m[0m[0m [0m[32ma[0m[0m [0m[31m([0m[0m[0m[7;93mf[27m[0m[0m [0m[31m([0m[0m[0m[7;93mwrap[27m[0m[0m [0m[32ma[0m[0m [0m[7;93mwork[27m[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m

--- a/tests/golden-ghc-7.11/last_Last_hs_NewLast_hss.ref
+++ b/tests/golden-ghc-7.11/last_Last_hs_NewLast_hss.ref
@@ -1,0 +1,49 @@
+===================== Welcome to HERMIT ======================
+HERMIT is a toolkit for the interactive transformation of GHC
+core language programs. Documentation on HERMIT can be found
+on the HERMIT web page at:
+http://www.ittc.ku.edu/csdl/fpg/software/hermit.html
+
+You have just loaded the interactive shell. To exit, type 
+"abort" or "resume" to abort or resume GHC compilation.
+
+Type "help" for instructions on how to list or search the
+available HERMIT commands.
+
+To get started, you could try the following:
+  - type "binding-of 'foo", where "foo" is a function
+    defined in the module;
+  - type "set-pp-type Show" to display full type information;
+  - type "info" for more information about the current node;
+  - to descend into a child node, type the name of the child
+    ("info" includes a list of children of the current node);
+  - to ascend, use the "up" command;
+  - type "log" to display an activity log.
+==============================================================
+
+Forcing obligation: last-assumption
+Successfully proven: last-assumption
+[0m[1;34mrec[22m[0m[0m [0m[mlast[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[31m.[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[0m[32ma[0m[0m[0m
+    [0m[mlast[0m[0m [0m[31m=[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[32ma[0m[0m [0m[31m[31m→[31m[0m[0m
+      [0m[1;34mlet[22m[0m[0m [0m[1;34mrec[22m[0m[0m [0m[mx[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[0m[32ma[0m[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[0m[32ma[0m[0m[0m
+              [0m[mx[0m[0m [0m[31m=[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[ma[0m[0m [0m[mas[0m[0m [0m[31m[31m→[31m[0m[0m
+                [0m[1;34mcase[22m[0m[0m [0m[0m[mas[0m[0m[0m [0m[1;34mof[22m[0m[0m [0m[mwild[0m[0m [0m[0m[32ma[0m[0m[0m
+                  [0m[m[][0m[0m [0m[31m[31m→[31m[0m[0m [0m[0m[ma[0m[0m[0m
+                  [0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[ma[0m[0m [0m[mas[0m[0m [0m[31m[31m→[31m[0m[0m [0m[0m[mx[0m[0m[0m [0m[0m[ma[0m[0m[0m [0m[0m[mas[0m[0m[0m
+      [0m[1;34min[22m[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[mds[0m[0m [0m[31m[31m→[31m[0m[0m
+           [0m[1;34mcase[22m[0m[0m [0m[0m[mds[0m[0m[0m [0m[1;34mof[22m[0m[0m [0m[mwild[0m[0m [0m[0m[32ma[0m[0m[0m
+             [0m[m[][0m[0m [0m[31m[31m→[31m[0m[0m [0m[mundefined[0m[0m [0m[0m[32ma[0m[0m[0m
+             [0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[ma[0m[0m [0m[mas[0m[0m [0m[31m[31m→[31m[0m[0m [0m[0m[mx[0m[0m[0m [0m[0m[ma[0m[0m[0m [0m[0m[mas[0m[0m[0m
+    [0m[mwrap[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[31m.[0m[0m [0m[31m([0m[0m[0m[0m[32ma[0m[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[0m[32ma[0m[0m[0m[0m[31m)[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[0m[32ma[0m[0m[0m
+    [0m[mwrap[0m[0m [0m[31m=[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[32ma[0m[0m [0m[mf[0m[0m [0m[mds[0m[0m [0m[31m[31m→[31m[0m[0m
+      [0m[1;34mcase[22m[0m[0m [0m[0m[mds[0m[0m[0m [0m[1;34mof[22m[0m[0m [0m[mwild[0m[0m [0m[0m[32ma[0m[0m[0m
+        [0m[m[][0m[0m [0m[31m[31m→[31m[0m[0m [0m[mundefined[0m[0m [0m[0m[32ma[0m[0m[0m
+        [0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[ma[0m[0m [0m[mas[0m[0m [0m[31m[31m→[31m[0m[0m [0m[0m[mf[0m[0m[0m [0m[0m[ma[0m[0m[0m [0m[0m[mas[0m[0m[0m
+    [0m[munwrap[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[31m.[0m[0m [0m[31m([0m[0m[0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[0m[32ma[0m[0m[0m[0m[31m)[0m[0m [0m[32m[32m→[32m[0m[0m [0m[0m[32ma[0m[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[0m[32ma[0m[0m[0m
+    [0m[munwrap[0m[0m [0m[31m=[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[32ma[0m[0m [0m[mf[0m[0m [0m[ma[0m[0m [0m[mas[0m[0m [0m[31m[31m→[31m[0m[0m [0m[0m[mf[0m[0m[0m [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[ma[0m[0m[0m [0m[0m[mas[0m[0m[0m[0m[31m)[0m[0m
+    [0m[mmain[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32mIO[0m[0m [0m[32m([0m[0m[0m[32m)[0m[0m
+    [0m[mmain[0m[0m [0m[31m=[0m[0m [0m[mprint[0m[0m [0m[32mChar[0m[0m [0m[m$fShowChar[0m[0m [0m[31m([0m[0m[0m[0m[mlast[0m[0m[0m [0m[32mChar[0m[0m [0m[31m([0m[0m[0m[munpackCString#[0m[0m [0m"hello"#[0m[0m[31m)[0m[0m[0m[31m)[0m[0m
+    [0m[mmain[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32mIO[0m[0m [0m[32m([0m[0m[0m[32m)[0m[0m
+    [0m[mmain[0m[0m [0m[31m=[0m[0m [0m[mrunMainIO[0m[0m [0m[32m([0m[0m[0m[32m)[0m[0m [0m[0m[mmain[0m[0m[0m[0m
+last-fusion (Built In)
+  [0m[7;93munwrap[27m[0m[0m [0m[32ma[0m[0m [0m[31m([0m[0m[0m[7;93mwrap[27m[0m[0m [0m[32ma[0m[0m [0m[31m([0m[0m[0m[mfix[0m[0m [0m[31m([0m[0m[0m[32ma[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[32ma[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32ma[0m[0m[0m[31m)[0m[0m [0m[7;93mg[27m[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[mfix[0m[0m [0m[31m([0m[0m[0m[32ma[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[32ma[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32ma[0m[0m[0m[31m)[0m[0m [0m[7;93mg[27m[0m[0m[0m

--- a/tests/golden-ghc-7.11/mean_Mean_hs_Mean_hss.ref
+++ b/tests/golden-ghc-7.11/mean_Mean_hs_Mean_hss.ref
@@ -1,0 +1,53 @@
+===================== Welcome to HERMIT ======================
+HERMIT is a toolkit for the interactive transformation of GHC
+core language programs. Documentation on HERMIT can be found
+on the HERMIT web page at:
+http://www.ittc.ku.edu/csdl/fpg/software/hermit.html
+
+You have just loaded the interactive shell. To exit, type 
+"abort" or "resume" to abort or resume GHC compilation.
+
+Type "help" for instructions on how to list or search the
+available HERMIT commands.
+
+To get started, you could try the following:
+  - type "binding-of 'foo", where "foo" is a function
+    defined in the module;
+  - type "set-pp-type Show" to display full type information;
+  - type "info" for more information about the current node;
+  - to descend into a child node, type the name of the child
+    ("info" includes a list of children of the current node);
+  - to ascend, use the "up" command;
+  - type "log" to display an activity log.
+==============================================================
+
+[0m[1;34mrec[22m[0m[0m [0m[msum[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32mInt[0m[0m
+    [0m[msum[0m[0m [0m[31m=[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[mds[0m[0m [0m[31m[31m→[31m[0m[0m
+      [0m[1;34mcase[22m[0m[0m [0m[0m[mds[0m[0m[0m [0m[1;34mof[22m[0m[0m [0m[mwild[0m[0m [0m[32mInt[0m[0m
+        [0m[m[][0m[0m [0m[31m[31m→[31m[0m[0m [0m[mI#[0m[0m [0m0#[0m
+        [0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[mx[0m[0m [0m[mxs[0m[0m [0m[31m[31m→[31m[0m[0m [0m[31m([0m[0m[0m[m+[0m[0m[0m[31m)[0m[0m [0m[32mInt[0m[0m [0m[m$fNumInt[0m[0m [0m[0m[mx[0m[0m[0m [0m[31m([0m[0m[0m[0m[msum[0m[0m[0m [0m[0m[mxs[0m[0m[0m[0m[31m)[0m[0m
+[0m[1;34mrec[22m[0m[0m [0m[mlength[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32mInt[0m[0m
+    [0m[mlength[0m[0m [0m[31m=[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[mds[0m[0m [0m[31m[31m→[31m[0m[0m
+      [0m[1;34mcase[22m[0m[0m [0m[0m[mds[0m[0m[0m [0m[1;34mof[22m[0m[0m [0m[mwild[0m[0m [0m[32mInt[0m[0m
+        [0m[m[][0m[0m [0m[31m[31m→[31m[0m[0m [0m[mI#[0m[0m [0m0#[0m
+        [0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[mx[0m[0m [0m[mxs[0m[0m [0m[31m[31m→[31m[0m[0m [0m[31m([0m[0m[0m[m+[0m[0m[0m[31m)[0m[0m [0m[32mInt[0m[0m [0m[m$fNumInt[0m[0m [0m[31m([0m[0m[0m[mI#[0m[0m [0m1#[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[0m[mlength[0m[0m[0m [0m[0m[mxs[0m[0m[0m[0m[31m)[0m[0m
+[0m[1;34mrec[22m[0m[0m [0m[msumlength[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m([0m[0m[0m[32mInt[0m[0m[0m[32m,[0m[0m [0m[32mInt[0m[0m[0m[32m)[0m[0m
+    [0m[msumlength[0m[0m [0m[31m=[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[mxs[0m[0m [0m[31m[31m→[31m[0m[0m
+      [0m[1;34mcase[22m[0m[0m [0m[0m[mxs[0m[0m[0m [0m[1;34mof[22m[0m[0m [0m[mw[0m[0m [0m[32m([0m[0m[0m[32mInt[0m[0m[0m[32m,[0m[0m [0m[32mInt[0m[0m[0m[32m)[0m[0m
+        [0m[m[][0m[0m [0m[31m[31m→[31m[0m[0m [0m[m(,)[0m[0m [0m[32mInt[0m[0m [0m[32mInt[0m[0m [0m[31m([0m[0m[0m[mI#[0m[0m [0m0#[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[mI#[0m[0m [0m0#[0m[0m[31m)[0m[0m
+        [0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[my[0m[0m [0m[mys[0m[0m [0m[31m[31m→[31m[0m[0m
+          [0m[1;34mcase[22m[0m[0m [0m[0m[msumlength[0m[0m[0m [0m[0m[mys[0m[0m[0m [0m[1;34mof[22m[0m[0m [0m[msl[0m[0m [0m[32m([0m[0m[0m[32mInt[0m[0m[0m[32m,[0m[0m [0m[32mInt[0m[0m[0m[32m)[0m[0m
+            [0m[m(,)[0m[0m [0m[ms[0m[0m [0m[ml[0m[0m [0m[31m[31m→[31m[0m[0m
+              [0m[m(,)[0m[0m [0m[32mInt[0m[0m [0m[32mInt[0m[0m [0m[31m([0m[0m[0m[31m([0m[0m[0m[m+[0m[0m[0m[31m)[0m[0m [0m[32mInt[0m[0m [0m[m$fNumInt[0m[0m [0m[0m[my[0m[0m[0m [0m[0m[ms[0m[0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[31m([0m[0m[0m[m+[0m[0m[0m[31m)[0m[0m [0m[32mInt[0m[0m [0m[m$fNumInt[0m[0m [0m[31m([0m[0m[0m[mI#[0m[0m [0m1#[0m[0m[31m)[0m[0m [0m[0m[ml[0m[0m[0m[0m[31m)[0m[0m
+[0m[mmean[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32mInt[0m[0m
+[0m[mmean[0m[0m [0m[31m=[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[mxs[0m[0m [0m[31m[31m→[31m[0m[0m
+  [0m[1;34mcase[22m[0m[0m [0m[0m[msumlength[0m[0m[0m [0m[0m[mxs[0m[0m[0m [0m[1;34mof[22m[0m[0m [0m[msl[0m[0m [0m[32mInt[0m[0m
+    [0m[m(,)[0m[0m [0m[ms[0m[0m [0m[ml[0m[0m [0m[31m[31m→[31m[0m[0m [0m[mdiv[0m[0m [0m[32mInt[0m[0m [0m[m$fIntegralInt[0m[0m [0m[0m[ms[0m[0m[0m [0m[0m[ml[0m[0m[0m
+[0m[mmain[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32mIO[0m[0m [0m[32m([0m[0m[0m[32m)[0m[0m
+[0m[mmain[0m[0m [0m[31m=[0m[0m
+  [0m[31m([0m[0m[0m[m$[0m[0m[0m[31m)[0m[0m [0m[32mInt[0m[0m [0m[31m([0m[0m[0m[32mIO[0m[0m [0m[32m([0m[0m[0m[32m)[0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[mprint[0m[0m [0m[32mInt[0m[0m [0m[m$fShowInt[0m[0m[0m[31m)[0m[0m
+      [0m[31m([0m[0m[0m[0m[mmean[0m[0m[0m [0m[31m([0m[0m[0m[menumFromTo[0m[0m [0m[32mInt[0m[0m [0m[m$fEnumInt[0m[0m [0m[31m([0m[0m[0m[mI#[0m[0m [0m1#[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[mI#[0m[0m [0m10#[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m
+[0m[mmain[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32mIO[0m[0m [0m[32m([0m[0m[0m[32m)[0m[0m
+[0m[mmain[0m[0m [0m[31m=[0m[0m [0m[mrunMainIO[0m[0m [0m[32m([0m[0m[0m[32m)[0m[0m [0m[0m[mmain[0m[0m[0m[0m
+remembered-sumlen (Proven)
+  [0m[31m[31m∀[31m[0m[0m [0m[mxs[0m[0m[0m[31m.[0m[0m [0m[7;93msumlength[27m[0m[0m [0m[0m[mxs[0m[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[m(,)[0m[0m [0m[32mInt[0m[0m [0m[32mInt[0m[0m [0m[31m([0m[0m[0m[7;93msum[27m[0m[0m [0m[0m[mxs[0m[0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[7;93mlength[27m[0m[0m [0m[0m[mxs[0m[0m[0m[0m[31m)[0m[0m[0m

--- a/tests/golden-ghc-7.11/new_reverse_Reverse_hs_Reverse_hec.ref
+++ b/tests/golden-ghc-7.11/new_reverse_Reverse_hs_Reverse_hec.ref
@@ -1,0 +1,95 @@
+===================== Welcome to HERMIT ======================
+HERMIT is a toolkit for the interactive transformation of GHC
+core language programs. Documentation on HERMIT can be found
+on the HERMIT web page at:
+http://www.ittc.ku.edu/csdl/fpg/software/hermit.html
+
+You have just loaded the interactive shell. To exit, type 
+"abort" or "resume" to abort or resume GHC compilation.
+
+Type "help" for instructions on how to list or search the
+available HERMIT commands.
+
+To get started, you could try the following:
+  - type "binding-of 'foo", where "foo" is a function
+    defined in the module;
+  - type "set-pp-type Show" to display full type information;
+  - type "info" for more information about the current node;
+  - to descend into a child node, type the name of the child
+    ("info" includes a list of children of the current node);
+  - to ascend, use the "up" command;
+  - type "log" to display an activity log.
+==============================================================
+
+++ [] (Not Proven)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[mxs[0m[0m[0m[31m.[0m[0m [0m[31m([0m[0m[0m[m++[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mxs[0m[0m[0m [0m[31m([0m[0m[0m[m[][0m[0m [0m[0m[32ma[0m[0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[0m[mxs[0m[0m[0m[0m
+Forcing obligation: appendFix
+Successfully proven: appendFix
+Successfully proven: ++ []
+myAppend-assoc (Not Proven)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[mxs[0m[0m [0m[mys[0m[0m [0m[mzs[0m[0m[0m[31m.[0m[0m
+  [0m[mmyAppend[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[mmyAppend[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mxs[0m[0m[0m [0m[0m[mys[0m[0m[0m[0m[31m)[0m[0m [0m[0m[mzs[0m[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[mmyAppend[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mxs[0m[0m[0m [0m[31m([0m[0m[0m[mmyAppend[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mys[0m[0m[0m [0m[0m[mzs[0m[0m[0m[0m[31m)[0m[0m[0m
+Successfully proven: myAppend-assoc
+repH [] (Not Proven)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m[0m[31m.[0m[0m [0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[m[][0m[0m [0m[0m[32ma[0m[0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[mid[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m[0m
+Successfully proven: repH []
+repH (:) (Not Proven)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[mx[0m[0m [0m[mxs[0m[0m[0m[31m.[0m[0m
+  [0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mx[0m[0m[0m [0m[0m[mxs[0m[0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[31m([0m[0m[0m[m.[0m[0m[0m[31m)[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mx[0m[0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mxs[0m[0m[0m[0m[31m)[0m[0m[0m
+Successfully proven: repH (:)
+repH ++ (Not Proven)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[mxs[0m[0m [0m[mys[0m[0m[0m[31m.[0m[0m
+  [0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[31m([0m[0m[0m[m++[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mxs[0m[0m[0m [0m[0m[mys[0m[0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[31m([0m[0m[0m[m.[0m[0m[0m[31m)[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[31m([0m[0m[0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mxs[0m[0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mys[0m[0m[0m[0m[31m)[0m[0m[0m
+Successfully proven: repH ++
+Forcing obligation: rev-assumption
+Successfully proven: rev-assumption
+Forcing obligation: repHstrict
+Successfully proven: repHstrict
+Forcing obligation: repH-absH-fusion
+Successfully proven: repH-absH-fusion
+[0m[1;34mrec[22m[0m[0m [0m[mrev[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[31m.[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m
+    [0m[mrev[0m[0m [0m[31m=[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[32ma[0m[0m [0m[31m[31m→[31m[0m[0m
+      [0m[1;34mlet[22m[0m[0m [0m[1;34mrec[22m[0m[0m [0m[mx[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32mH[0m[0m [0m[0m[32ma[0m[0m[0m
+              [0m[mx[0m[0m [0m[31m=[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[mx0[0m[0m [0m[31m[31m→[31m[0m[0m
+                [0m[1;34mcase[22m[0m[0m [0m[0m[mx0[0m[0m[0m [0m[1;34mof[22m[0m[0m [0m[mwild[0m[0m [0m[31m([0m[0m[0m[32mH[0m[0m [0m[0m[32ma[0m[0m[0m[0m[31m)[0m[0m
+                  [0m[m[][0m[0m [0m[31m[31m→[31m[0m[0m [0m[mid[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m
+                  [0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[mx1[0m[0m [0m[mxs[0m[0m [0m[31m[31m→[31m[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[mx2[0m[0m [0m[31m[31m→[31m[0m[0m [0m[0m[mx[0m[0m[0m [0m[0m[mxs[0m[0m[0m [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mx1[0m[0m[0m [0m[0m[mx2[0m[0m[0m[0m[31m)[0m[0m
+      [0m[1;34min[22m[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[mx0[0m[0m [0m[31m[31m→[31m[0m[0m [0m[0m[mx[0m[0m[0m [0m[0m[mx0[0m[0m[0m [0m[31m([0m[0m[0m[m[][0m[0m [0m[0m[32ma[0m[0m[0m[0m[31m)[0m[0m
+    [0m[mabsR[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[31m.[0m[0m [0m[31m([0m[0m[0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32mH[0m[0m [0m[0m[32ma[0m[0m[0m[0m[31m)[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m
+    [0m[mabsR[0m[0m [0m[31m=[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[32ma[0m[0m [0m[meta[0m[0m [0m[31m[31m→[31m[0m[0m [0m[31m([0m[0m[0m[31m[31mλ[31m[0m[0m [0m[mg[0m[0m [0m[31m[31m→[31m[0m[0m [0m[31m([0m[0m[0m[m.[0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[32mH[0m[0m [0m[0m[32ma[0m[0m[0m[0m[31m)[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[31m([0m[0m[0m[mabsH[0m[0m [0m[0m[32ma[0m[0m[0m[0m[31m)[0m[0m [0m[0m[mg[0m[0m[0m[0m[31m)[0m[0m [0m[0m[meta[0m[0m[0m
+    [0m[mrepR[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[31m.[0m[0m [0m[31m([0m[0m[0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m[0m[31m)[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32mH[0m[0m [0m[0m[32ma[0m[0m[0m
+    [0m[mrepR[0m[0m [0m[31m=[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[32ma[0m[0m [0m[meta[0m[0m [0m[31m[31m→[31m[0m[0m [0m[31m([0m[0m[0m[31m[31mλ[31m[0m[0m [0m[mf[0m[0m [0m[31m[31m→[31m[0m[0m [0m[31m([0m[0m[0m[m.[0m[0m[0m[31m)[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[31m([0m[0m[0m[32mH[0m[0m [0m[0m[32ma[0m[0m[0m[0m[31m)[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[31m([0m[0m[0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m[0m[31m)[0m[0m [0m[0m[mf[0m[0m[0m[0m[31m)[0m[0m [0m[0m[meta[0m[0m[0m
+    [0m[mmain[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32mIO[0m[0m [0m[32m([0m[0m[0m[32m)[0m[0m
+    [0m[mmain[0m[0m [0m[31m=[0m[0m
+      [0m[31m([0m[0m[0m[m$[0m[0m[0m[31m)[0m[0m [0m[32m[[0m[0m[0m[32mInteger[0m[0m[0m[32m][0m[0m [0m[31m([0m[0m[0m[32mIO[0m[0m [0m[32m([0m[0m[0m[32m)[0m[0m[0m[31m)[0m[0m
+          [0m[31m([0m[0m[0m[mprint[0m[0m [0m[32m[[0m[0m[0m[32mInteger[0m[0m[0m[32m][0m[0m [0m[31m([0m[0m[0m[m$fShow[][0m[0m [0m[32mInteger[0m[0m [0m[m$fShowInteger[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m
+          [0m[31m([0m[0m[0m[0m[mrev[0m[0m[0m [0m[32mInteger[0m[0m [0m[31m([0m[0m[0m[menumFromTo[0m[0m [0m[32mInteger[0m[0m [0m[m$fEnumInteger[0m[0m [0m1[0m [0m10[0m[0m[31m)[0m[0m[0m[31m)[0m[0m
+    [0m[mmain[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32mIO[0m[0m [0m[32m([0m[0m[0m[32m)[0m[0m
+    [0m[mmain[0m[0m [0m[31m=[0m[0m [0m[mrunMainIO[0m[0m [0m[32m([0m[0m[0m[32m)[0m[0m [0m[0m[mmain[0m[0m[0m[0m
+++ [] (Proven)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[mxs[0m[0m[0m[31m.[0m[0m [0m[31m([0m[0m[0m[m++[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mxs[0m[0m[0m [0m[31m([0m[0m[0m[m[][0m[0m [0m[0m[32ma[0m[0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[0m[mxs[0m[0m[0m
+appendFix (Assumed)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m[0m[31m.[0m[0m [0m[31m([0m[0m[0m[m++[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[mmyAppend[0m[0m [0m[0m[32ma[0m[0m[0m
+myAppend-assoc (Proven)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[mxs[0m[0m [0m[mys[0m[0m [0m[mzs[0m[0m[0m[31m.[0m[0m
+  [0m[mmyAppend[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[mmyAppend[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mxs[0m[0m[0m [0m[0m[mys[0m[0m[0m[0m[31m)[0m[0m [0m[0m[mzs[0m[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[mmyAppend[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mxs[0m[0m[0m [0m[31m([0m[0m[0m[mmyAppend[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mys[0m[0m[0m [0m[0m[mzs[0m[0m[0m[0m[31m)[0m[0m
+repH (:) (Proven)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[mx[0m[0m [0m[mxs[0m[0m[0m[31m.[0m[0m
+  [0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mx[0m[0m[0m [0m[0m[mxs[0m[0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[31m([0m[0m[0m[m.[0m[0m[0m[31m)[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mx[0m[0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mxs[0m[0m[0m[0m[31m)[0m[0m
+repH ++ (Proven)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[mxs[0m[0m [0m[mys[0m[0m[0m[31m.[0m[0m
+  [0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[31m([0m[0m[0m[m++[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mxs[0m[0m[0m [0m[0m[mys[0m[0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[31m([0m[0m[0m[m.[0m[0m[0m[31m)[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[31m([0m[0m[0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mxs[0m[0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mys[0m[0m[0m[0m[31m)[0m[0m
+repH [] (Proven)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m[0m[31m.[0m[0m [0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[m[][0m[0m [0m[0m[32ma[0m[0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[mid[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m
+repH-absH-fusion (Assumed)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[mh[0m[0m[0m[31m.[0m[0m [0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[mabsH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mh[0m[0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[0m[mh[0m[0m[0m
+repHstrict (Proven)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m[0m[31m.[0m[0m [0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[mundefined[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[mundefined[0m[0m [0m[31m([0m[0m[0m[32mH[0m[0m [0m[0m[32ma[0m[0m[0m[0m[31m)[0m[0m
+rev-fusion (Built In)
+  [0m[7;93mrepR[27m[0m[0m [0m[32ma[0m[0m [0m[31m([0m[0m[0m[7;93mabsR[27m[0m[0m [0m[32ma[0m[0m [0m[31m([0m[0m[0m[mfix[0m[0m [0m[31m([0m[0m[0m[32m[[0m[0m[0m[32ma[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32mH[0m[0m [0m[32ma[0m[0m[0m[31m)[0m[0m [0m[7;93mg[27m[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[mfix[0m[0m [0m[31m([0m[0m[0m[32m[[0m[0m[0m[32ma[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32mH[0m[0m [0m[32ma[0m[0m[0m[31m)[0m[0m [0m[7;93mg[27m[0m[0m[0m
+Warning: Lemma appendFix was assumed but not proven.
+appendFix
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m[0m[31m.[0m[0m [0m[31m([0m[0m[0m[m++[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[mmyAppend[0m[0m [0m[0m[32ma[0m[0m[0m[0m
+Warning: Lemma repH-absH-fusion was assumed but not proven.
+repH-absH-fusion
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[mh[0m[0m[0m[31m.[0m[0m [0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[mabsH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mh[0m[0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[0m[mh[0m[0m[0m[0m

--- a/tests/golden-ghc-7.11/nub_Nub_hs_Nub_hss.ref
+++ b/tests/golden-ghc-7.11/nub_Nub_hs_Nub_hss.ref
@@ -1,0 +1,145 @@
+===================== Welcome to HERMIT ======================
+HERMIT is a toolkit for the interactive transformation of GHC
+core language programs. Documentation on HERMIT can be found
+on the HERMIT web page at:
+http://www.ittc.ku.edu/csdl/fpg/software/hermit.html
+
+You have just loaded the interactive shell. To exit, type 
+"abort" or "resume" to abort or resume GHC compilation.
+
+Type "help" for instructions on how to list or search the
+available HERMIT commands.
+
+To get started, you could try the following:
+  - type "binding-of 'foo", where "foo" is a function
+    defined in the module;
+  - type "set-pp-type Show" to display full type information;
+  - type "info" for more information about the current node;
+  - to descend into a child node, type the name of the child
+    ("info" includes a list of children of the current node);
+  - to ascend, use the "up" command;
+  - type "log" to display an activity log.
+==============================================================
+
+Forcing obligation: nub-assumption
+Successfully proven: nub-assumption
+Forcing obligation: nubStrict
+Successfully proven: nubStrict
+Forcing obligation: nubStrict
+Successfully proven: nubStrict
+Forcing obligation: filter-fusion
+Successfully proven: filter-fusion
+Forcing obligation: member-fusion
+Successfully proven: member-fusion
+[0m[1;34mrec[22m[0m[0m [0m[mabsN[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[31m([0m[0m[0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32mSet[0m[0m [0m[32mInt[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m[0m[31m)[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m
+    [0m[mabsN[0m[0m [0m[31m=[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[mh[0m[0m [0m[mds[0m[0m [0m[31m[31m→[31m[0m[0m
+      [0m[1;34mcase[22m[0m[0m [0m[0m[mds[0m[0m[0m [0m[1;34mof[22m[0m[0m [0m[mwild[0m[0m [0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m
+        [0m[m[][0m[0m [0m[31m[31m→[31m[0m[0m [0m[m[][0m[0m [0m[32mInt[0m[0m
+        [0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[mx[0m[0m [0m[mxs[0m[0m [0m[31m[31m→[31m[0m[0m [0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[32mInt[0m[0m [0m[0m[mx[0m[0m[0m [0m[31m([0m[0m[0m[0m[mh[0m[0m[0m [0m[0m[mxs[0m[0m[0m [0m[31m([0m[0m[0m[msingleton[0m[0m [0m[32mInt[0m[0m [0m[0m[mx[0m[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m
+    [0m[mfilter[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[31m.[0m[0m [0m[31m([0m[0m[0m[0m[32ma[0m[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32mBool[0m[0m[0m[31m)[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m
+    [0m[mfilter[0m[0m [0m[31m=[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[32ma[0m[0m [0m[mds[0m[0m [0m[mds[0m[0m [0m[31m[31m→[31m[0m[0m
+      [0m[1;34mcase[22m[0m[0m [0m[0m[mds[0m[0m[0m [0m[1;34mof[22m[0m[0m [0m[mwild[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m
+        [0m[m[][0m[0m [0m[31m[31m→[31m[0m[0m [0m[m[][0m[0m [0m[0m[32ma[0m[0m[0m
+        [0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[mx[0m[0m [0m[mxs[0m[0m [0m[31m[31m→[31m[0m[0m
+          [0m[1;34mcase[22m[0m[0m [0m[0m[mds[0m[0m[0m [0m[0m[mx[0m[0m[0m [0m[1;34mof[22m[0m[0m [0m[mwild[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m
+            [0m[mFalse[0m[0m [0m[31m[31m→[31m[0m[0m [0m[0m[mfilter[0m[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mds[0m[0m[0m [0m[0m[mxs[0m[0m[0m
+            [0m[mTrue[0m[0m [0m[31m[31m→[31m[0m[0m [0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mx[0m[0m[0m [0m[31m([0m[0m[0m[0m[mfilter[0m[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mds[0m[0m[0m [0m[0m[mxs[0m[0m[0m[0m[31m)[0m[0m
+    [0m[mrepN[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[31m([0m[0m[0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m[0m[31m)[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32mSet[0m[0m [0m[32mInt[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m
+    [0m[mrepN[0m[0m [0m[31m=[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[mh[0m[0m [0m[mxs[0m[0m [0m[ms[0m[0m [0m[31m[31m→[31m[0m[0m
+      [0m[0m[mh[0m[0m[0m [0m[31m([0m[0m[0m[0m[mfilter[0m[0m[0m [0m[32mInt[0m[0m [0m[31m([0m[0m[0m[31m[31mλ[31m[0m[0m [0m[mds[0m[0m [0m[31m[31m→[31m[0m[0m [0m[mnotMember[0m[0m [0m[32mInt[0m[0m [0m[m$fOrdInt[0m[0m [0m[0m[mds[0m[0m[0m [0m[0m[ms[0m[0m[0m[0m[31m)[0m[0m [0m[0m[mxs[0m[0m[0m[0m[31m)[0m[0m
+    [0m[m$dShow[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32mShow[0m[0m [0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m
+    [0m[m$dShow[0m[0m [0m[31m=[0m[0m [0m[m$fShow[][0m[0m [0m[32mInt[0m[0m [0m[m$fShowInt[0m[0m
+    [0m[mnub[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m
+    [0m[mnub[0m[0m [0m[31m=[0m[0m
+      [0m[1;34mlet[22m[0m[0m [0m[1;34mrec[22m[0m[0m [0m[mnub'[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m
+              [0m[mnub'[0m[0m [0m[31m=[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[mds[0m[0m [0m[31m[31m→[31m[0m[0m
+                [0m[1;34mcase[22m[0m[0m [0m[0m[mds[0m[0m[0m [0m[1;34mof[22m[0m[0m [0m[mwild[0m[0m [0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m
+                  [0m[m[][0m[0m [0m[31m[31m→[31m[0m[0m [0m[m[][0m[0m [0m[32mInt[0m[0m
+                  [0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[mx[0m[0m [0m[mxs[0m[0m [0m[31m[31m→[31m[0m[0m
+                    [0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[32mInt[0m[0m [0m[0m[mx[0m[0m[0m
+                        [0m[31m([0m[0m[0m[0m[mnub'[0m[0m[0m [0m[31m([0m[0m[0m[0m[mfilter[0m[0m[0m [0m[32mInt[0m[0m [0m[31m([0m[0m[0m[31m[31mλ[31m[0m[0m [0m[mds[0m[0m [0m[31m[31m→[31m[0m[0m [0m[31m([0m[0m[0m[m/=[0m[0m[0m[31m)[0m[0m [0m[32mInt[0m[0m [0m[m$fEqInt[0m[0m [0m[0m[mds[0m[0m[0m [0m[0m[mx[0m[0m[0m[0m[31m)[0m[0m [0m[0m[mxs[0m[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m
+          [0m[1;34mrec[22m[0m[0m [0m[mworker[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32mSet[0m[0m [0m[32mInt[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m
+              [0m[mworker[0m[0m [0m[31m=[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[mxs[0m[0m [0m[ms[0m[0m [0m[31m[31m→[31m[0m[0m
+                [0m[1;34mcase[22m[0m[0m [0m[0m[mxs[0m[0m[0m [0m[1;34mof[22m[0m[0m [0m[mwild[0m[0m [0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m
+                  [0m[m[][0m[0m [0m[31m[31m→[31m[0m[0m [0m[m[][0m[0m [0m[32mInt[0m[0m
+                  [0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[mx[0m[0m [0m[mxs[0m[0m [0m[31m[31m→[31m[0m[0m
+                    [0m[1;34mcase[22m[0m[0m [0m[mnotMember[0m[0m [0m[32mInt[0m[0m [0m[m$fOrdInt[0m[0m [0m[0m[mx[0m[0m[0m [0m[0m[ms[0m[0m[0m [0m[1;34mof[22m[0m[0m [0m[mwild[0m[0m [0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m
+                      [0m[mFalse[0m[0m [0m[31m[31m→[31m[0m[0m [0m[0m[mworker[0m[0m[0m [0m[0m[mxs[0m[0m[0m [0m[0m[ms[0m[0m[0m
+                      [0m[mTrue[0m[0m [0m[31m[31m→[31m[0m[0m [0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[32mInt[0m[0m [0m[0m[mx[0m[0m[0m [0m[31m([0m[0m[0m[0m[mworker[0m[0m[0m [0m[0m[mxs[0m[0m[0m [0m[31m([0m[0m[0m[minsert[0m[0m [0m[32mInt[0m[0m [0m[m$fOrdInt[0m[0m [0m[0m[mx[0m[0m[0m [0m[0m[ms[0m[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m
+      [0m[1;34min[22m[0m[0m [0m[0m[mabsN[0m[0m[0m [0m[0m[mworker[0m[0m[0m
+    [0m[mmain[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32mIO[0m[0m [0m[32m([0m[0m[0m[32m)[0m[0m
+    [0m[mmain[0m[0m [0m[31m=[0m[0m
+      [0m[mprint[0m[0m [0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m [0m[0m[m$dShow[0m[0m[0m
+            [0m[31m([0m[0m[0m[0m[mnub[0m[0m[0m [0m[31m([0m[0m[0m[mbuild[0m[0m [0m[32mInt[0m[0m
+                        [0m[31m([0m[0m[0m[31m[31mλ[31m[0m[0m [0m[32ma[0m[0m [0m[mc[0m[0m [0m[mn[0m[0m [0m[31m[31m→[31m[0m[0m
+                           [0m[mfoldr[0m[0m [0m[32mInt[0m[0m [0m[0m[32ma[0m[0m[0m
+                                 [0m[31m([0m[0m[0m[31m[31mλ[31m[0m[0m [0m[mds[0m[0m [0m[mds[0m[0m [0m[31m[31m→[31m[0m[0m
+                                    [0m[mfoldr[0m[0m [0m[32mInt[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[31m[31mλ[31m[0m[0m [0m[mds[0m[0m [0m[mds[0m[0m [0m[31m[31m→[31m[0m[0m [0m[0m[mc[0m[0m[0m [0m[0m[mds[0m[0m[0m [0m[0m[mds[0m[0m[0m[0m[31m)[0m[0m [0m[0m[mds[0m[0m[0m
+                                          [0m[31m([0m[0m[0m[menumFromTo[0m[0m [0m[32mInt[0m[0m [0m[m$fEnumInt[0m[0m [0m[31m([0m[0m[0m[mI#[0m[0m [0m1#[0m[0m[31m)[0m[0m [0m[0m[mds[0m[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m
+                                 [0m[0m[mn[0m[0m[0m
+                                 [0m[31m([0m[0m[0m[menumFromTo[0m[0m [0m[32mInt[0m[0m [0m[m$fEnumInt[0m[0m [0m[31m([0m[0m[0m[mI#[0m[0m [0m1#[0m[0m[31m)[0m[0m
+                                             [0m[31m([0m[0m[0m[mI#[0m[0m [0m1000#[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m
+    [0m[mmain[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32mIO[0m[0m [0m[32m([0m[0m[0m[32m)[0m[0m
+    [0m[mmain[0m[0m [0m[31m=[0m[0m [0m[mrunMainIO[0m[0m [0m[32m([0m[0m[0m[32m)[0m[0m [0m[0m[mmain[0m[0m[0m[0m
+filter-fusion (Assumed)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[mp[0m[0m [0m[mq[0m[0m [0m[mys[0m[0m[0m[31m.[0m[0m
+  [0m[7;93mfilter[27m[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mp[0m[0m[0m [0m[31m([0m[0m[0m[7;93mfilter[27m[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mq[0m[0m[0m [0m[0m[mys[0m[0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[7;93mfilter[27m[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[31m[31mλ[31m[0m[0m [0m[my[0m[0m [0m[31m[31m→[31m[0m[0m [0m[31m([0m[0m[0m[m&&[0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[0m[mp[0m[0m[0m [0m[0m[my[0m[0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[0m[mq[0m[0m[0m [0m[0m[my[0m[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m [0m[0m[mys[0m[0m[0m
+member-fusion (Assumed)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[m$dEq[0m[0m [0m[m$dOrd[0m[0m [0m[my[0m[0m [0m[mx[0m[0m [0m[ms[0m[0m[0m[31m.[0m[0m
+  [0m[31m([0m[0m[0m[m&&[0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[31m([0m[0m[0m[m/=[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[m$dEq[0m[0m[0m [0m[0m[my[0m[0m[0m [0m[0m[mx[0m[0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[mnotMember[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[m$dOrd[0m[0m[0m [0m[0m[my[0m[0m[0m [0m[0m[ms[0m[0m[0m[0m[31m)[0m[0m
+  [0m[31m[31m≡[31m[0m[0m
+  [0m[mnotMember[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[m$dOrd[0m[0m[0m [0m[0m[my[0m[0m[0m [0m[31m([0m[0m[0m[minsert[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[m$dOrd[0m[0m[0m [0m[0m[mx[0m[0m[0m [0m[0m[ms[0m[0m[0m[0m[31m)[0m[0m
+nub-assumption (Assumed)
+  [0m[mfix[0m[0m [0m[31m([0m[0m[0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m[0m[31m)[0m[0m
+      [0m[31m([0m[0m[0m[31m([0m[0m[0m[m.[0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32mSet[0m[0m [0m[32mInt[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m[0m[31m)[0m[0m [0m[7;93mabsN[27m[0m[0m
+           [0m[31m([0m[0m[0m[31m([0m[0m[0m[m.[0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32mSet[0m[0m [0m[32mInt[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m[0m[31m)[0m[0m [0m[7;93mrepN[27m[0m[0m
+                [0m[31m([0m[0m[0m[31m[31mλ[31m[0m[0m [0m[mnub[0m[0m [0m[mds[0m[0m [0m[31m[31m→[31m[0m[0m
+                   [0m[1;34mcase[22m[0m[0m [0m[0m[mds[0m[0m[0m [0m[1;34mof[22m[0m[0m [0m[mwild[0m[0m [0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m
+                     [0m[m[][0m[0m [0m[31m[31m→[31m[0m[0m [0m[m[][0m[0m [0m[32mInt[0m[0m
+                     [0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[mx[0m[0m [0m[mxs[0m[0m [0m[31m[31m→[31m[0m[0m
+                       [0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[32mInt[0m[0m [0m[0m[mx[0m[0m[0m
+                           [0m[31m([0m[0m[0m[0m[mnub[0m[0m[0m [0m[31m([0m[0m[0m[7;93mfilter[27m[0m[0m [0m[32mInt[0m[0m [0m[31m([0m[0m[0m[31m[31mλ[31m[0m[0m [0m[mds[0m[0m [0m[31m[31m→[31m[0m[0m [0m[31m([0m[0m[0m[m/=[0m[0m[0m[31m)[0m[0m [0m[32mInt[0m[0m [0m[m$fEqInt[0m[0m [0m[0m[mds[0m[0m[0m [0m[0m[mx[0m[0m[0m[0m[31m)[0m[0m
+                                        [0m[0m[mxs[0m[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m
+  [0m[31m[31m≡[31m[0m[0m
+  [0m[mfix[0m[0m [0m[31m([0m[0m[0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m[0m[31m)[0m[0m
+      [0m[31m([0m[0m[0m[31m[31mλ[31m[0m[0m [0m[mnub[0m[0m [0m[mds[0m[0m [0m[31m[31m→[31m[0m[0m
+         [0m[1;34mcase[22m[0m[0m [0m[0m[mds[0m[0m[0m [0m[1;34mof[22m[0m[0m [0m[mwild[0m[0m [0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m
+           [0m[m[][0m[0m [0m[31m[31m→[31m[0m[0m [0m[m[][0m[0m [0m[32mInt[0m[0m
+           [0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[mx[0m[0m [0m[mxs[0m[0m [0m[31m[31m→[31m[0m[0m
+             [0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[32mInt[0m[0m [0m[0m[mx[0m[0m[0m [0m[31m([0m[0m[0m[0m[mnub[0m[0m[0m [0m[31m([0m[0m[0m[7;93mfilter[27m[0m[0m [0m[32mInt[0m[0m [0m[31m([0m[0m[0m[31m[31mλ[31m[0m[0m [0m[mds[0m[0m [0m[31m[31m→[31m[0m[0m [0m[31m([0m[0m[0m[m/=[0m[0m[0m[31m)[0m[0m [0m[32mInt[0m[0m [0m[m$fEqInt[0m[0m [0m[0m[mds[0m[0m[0m [0m[0m[mx[0m[0m[0m[0m[31m)[0m[0m [0m[0m[mxs[0m[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m
+nub-fusion (Built In)
+  [0m[7;93mrepN[27m[0m[0m [0m[31m([0m[0m[0m[7;93mabsN[27m[0m[0m [0m[7;93mworker[27m[0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[7;93mworker[27m[0m[0m
+remembered-origworker (Proven)
+  [0m[31m[31m∀[31m[0m[0m [0m[mxs[0m[0m [0m[ms[0m[0m[0m[31m.[0m[0m
+  [0m[7;93mworker[27m[0m[0m [0m[0m[mxs[0m[0m[0m [0m[0m[ms[0m[0m[0m
+  [0m[31m[31m≡[31m[0m[0m
+  [0m[7;93mnub'[27m[0m[0m [0m[31m([0m[0m[0m[7;93mfilter[27m[0m[0m [0m[32mInt[0m[0m [0m[31m([0m[0m[0m[31m[31mλ[31m[0m[0m [0m[mds[0m[0m [0m[31m[31m→[31m[0m[0m [0m[mnotMember[0m[0m [0m[32mInt[0m[0m [0m[m$fOrdInt[0m[0m [0m[0m[mds[0m[0m[0m [0m[0m[ms[0m[0m[0m[0m[31m)[0m[0m [0m[0m[mxs[0m[0m[0m[0m[31m)[0m[0m[0m
+Warning: Lemma filter-fusion was assumed but not proven.
+filter-fusion
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[mp[0m[0m [0m[mq[0m[0m [0m[mys[0m[0m[0m[31m.[0m[0m
+  [0m[7;93mfilter[27m[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mp[0m[0m[0m [0m[31m([0m[0m[0m[7;93mfilter[27m[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mq[0m[0m[0m [0m[0m[mys[0m[0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[7;93mfilter[27m[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[31m[31mλ[31m[0m[0m [0m[my[0m[0m [0m[31m[31m→[31m[0m[0m [0m[31m([0m[0m[0m[m&&[0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[0m[mp[0m[0m[0m [0m[0m[my[0m[0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[0m[mq[0m[0m[0m [0m[0m[my[0m[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m [0m[0m[mys[0m[0m[0m[0m
+Warning: Lemma member-fusion was assumed but not proven.
+member-fusion
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[m$dEq[0m[0m [0m[m$dOrd[0m[0m [0m[my[0m[0m [0m[mx[0m[0m [0m[ms[0m[0m[0m[31m.[0m[0m
+  [0m[31m([0m[0m[0m[m&&[0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[31m([0m[0m[0m[m/=[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[m$dEq[0m[0m[0m [0m[0m[my[0m[0m[0m [0m[0m[mx[0m[0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[mnotMember[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[m$dOrd[0m[0m[0m [0m[0m[my[0m[0m[0m [0m[0m[ms[0m[0m[0m[0m[31m)[0m[0m
+  [0m[31m[31m≡[31m[0m[0m
+  [0m[mnotMember[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[m$dOrd[0m[0m[0m [0m[0m[my[0m[0m[0m [0m[31m([0m[0m[0m[minsert[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[m$dOrd[0m[0m[0m [0m[0m[mx[0m[0m[0m [0m[0m[ms[0m[0m[0m[0m[31m)[0m[0m[0m
+Warning: Lemma nub-assumption was assumed but not proven.
+nub-assumption
+  [0m[mfix[0m[0m [0m[31m([0m[0m[0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m[0m[31m)[0m[0m
+      [0m[31m([0m[0m[0m[31m([0m[0m[0m[m.[0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32mSet[0m[0m [0m[32mInt[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m[0m[31m)[0m[0m [0m[7;93mabsN[27m[0m[0m
+           [0m[31m([0m[0m[0m[31m([0m[0m[0m[m.[0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32mSet[0m[0m [0m[32mInt[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m[0m[31m)[0m[0m [0m[7;93mrepN[27m[0m[0m
+                [0m[31m([0m[0m[0m[31m[31mλ[31m[0m[0m [0m[mnub[0m[0m [0m[mds[0m[0m [0m[31m[31m→[31m[0m[0m
+                   [0m[1;34mcase[22m[0m[0m [0m[0m[mds[0m[0m[0m [0m[1;34mof[22m[0m[0m [0m[mwild[0m[0m [0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m
+                     [0m[m[][0m[0m [0m[31m[31m→[31m[0m[0m [0m[m[][0m[0m [0m[32mInt[0m[0m
+                     [0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[mx[0m[0m [0m[mxs[0m[0m [0m[31m[31m→[31m[0m[0m
+                       [0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[32mInt[0m[0m [0m[0m[mx[0m[0m[0m
+                           [0m[31m([0m[0m[0m[0m[mnub[0m[0m[0m [0m[31m([0m[0m[0m[7;93mfilter[27m[0m[0m [0m[32mInt[0m[0m [0m[31m([0m[0m[0m[31m[31mλ[31m[0m[0m [0m[mds[0m[0m [0m[31m[31m→[31m[0m[0m [0m[31m([0m[0m[0m[m/=[0m[0m[0m[31m)[0m[0m [0m[32mInt[0m[0m [0m[m$fEqInt[0m[0m [0m[0m[mds[0m[0m[0m [0m[0m[mx[0m[0m[0m[0m[31m)[0m[0m
+                                        [0m[0m[mxs[0m[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m
+  [0m[31m[31m≡[31m[0m[0m
+  [0m[mfix[0m[0m [0m[31m([0m[0m[0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m[0m[31m)[0m[0m
+      [0m[31m([0m[0m[0m[31m[31mλ[31m[0m[0m [0m[mnub[0m[0m [0m[mds[0m[0m [0m[31m[31m→[31m[0m[0m
+         [0m[1;34mcase[22m[0m[0m [0m[0m[mds[0m[0m[0m [0m[1;34mof[22m[0m[0m [0m[mwild[0m[0m [0m[32m[[0m[0m[0m[32mInt[0m[0m[0m[32m][0m[0m
+           [0m[m[][0m[0m [0m[31m[31m→[31m[0m[0m [0m[m[][0m[0m [0m[32mInt[0m[0m
+           [0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[mx[0m[0m [0m[mxs[0m[0m [0m[31m[31m→[31m[0m[0m
+             [0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[32mInt[0m[0m [0m[0m[mx[0m[0m[0m [0m[31m([0m[0m[0m[0m[mnub[0m[0m[0m [0m[31m([0m[0m[0m[7;93mfilter[27m[0m[0m [0m[32mInt[0m[0m [0m[31m([0m[0m[0m[31m[31mλ[31m[0m[0m [0m[mds[0m[0m [0m[31m[31m→[31m[0m[0m [0m[31m([0m[0m[0m[m/=[0m[0m[0m[31m)[0m[0m [0m[32mInt[0m[0m [0m[m$fEqInt[0m[0m [0m[0m[mds[0m[0m[0m [0m[0m[mx[0m[0m[0m[0m[31m)[0m[0m [0m[0m[mxs[0m[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m

--- a/tests/golden-ghc-7.11/qsort_QSort_hs_QSort_hss.ref
+++ b/tests/golden-ghc-7.11/qsort_QSort_hs_QSort_hss.ref
@@ -1,0 +1,106 @@
+===================== Welcome to HERMIT ======================
+HERMIT is a toolkit for the interactive transformation of GHC
+core language programs. Documentation on HERMIT can be found
+on the HERMIT web page at:
+http://www.ittc.ku.edu/csdl/fpg/software/hermit.html
+
+You have just loaded the interactive shell. To exit, type 
+"abort" or "resume" to abort or resume GHC compilation.
+
+Type "help" for instructions on how to list or search the
+available HERMIT commands.
+
+To get started, you could try the following:
+  - type "binding-of 'foo", where "foo" is a function
+    defined in the module;
+  - type "set-pp-type Show" to display full type information;
+  - type "info" for more information about the current node;
+  - to descend into a child node, type the name of the child
+    ("info" includes a list of children of the current node);
+  - to ascend, use the "up" command;
+  - type "log" to display an activity log.
+==============================================================
+
+Forcing obligation: qsort-assumption
+Successfully proven: qsort-assumption
+Forcing obligation: repHstrict
+Successfully proven: repHstrict
+Forcing obligation: repH ++
+Successfully proven: repH ++
+Forcing obligation: repH-absH-fusion
+Successfully proven: repH-absH-fusion
+Forcing obligation: repH []
+Forcing obligation: repH (:)
+Successfully proven: repH (:)
+Successfully proven: repH []
+[0m[1;34mrec[22m[0m[0m [0m[mqsort[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[31m.[0m[0m [0m[32mOrd[0m[0m [0m[0m[32ma[0m[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m
+    [0m[mqsort[0m[0m [0m[31m=[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[32ma[0m[0m [0m[m$dOrd[0m[0m [0m[31m[31m→[31m[0m[0m
+      [0m[1;34mlet[22m[0m[0m [0m[1;34mrec[22m[0m[0m [0m[mworker[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32mH[0m[0m [0m[0m[32ma[0m[0m[0m
+              [0m[mworker[0m[0m [0m[31m=[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[mx0[0m[0m [0m[31m[31m→[31m[0m[0m
+                [0m[1;34mcase[22m[0m[0m [0m[0m[mx0[0m[0m[0m [0m[1;34mof[22m[0m[0m [0m[mwild[0m[0m [0m[31m([0m[0m[0m[32mH[0m[0m [0m[0m[32ma[0m[0m[0m[0m[31m)[0m[0m
+                  [0m[m[][0m[0m [0m[31m[31m→[31m[0m[0m [0m[mid[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m
+                  [0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[ma0[0m[0m [0m[mas[0m[0m [0m[31m[31m→[31m[0m[0m
+                    [0m[1;34mlet[22m[0m[0m [0m[mds0[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32m([0m[0m[0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m[0m[32m,[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m[0m[32m)[0m[0m
+                        [0m[mds0[0m[0m [0m[31m=[0m[0m [0m[mpartition[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[31m[31mλ[31m[0m[0m [0m[mds0[0m[0m [0m[31m[31m→[31m[0m[0m [0m[31m([0m[0m[0m[m<[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[m$dOrd[0m[0m[0m [0m[0m[mds0[0m[0m[0m [0m[0m[ma0[0m[0m[0m[0m[31m)[0m[0m [0m[0m[mas[0m[0m[0m
+                    [0m[1;34min[22m[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[mx[0m[0m [0m[31m[31m→[31m[0m[0m
+                         [0m[0m[mworker[0m[0m[0m [0m[31m([0m[0m[0m[1;34mcase[22m[0m[0m [0m[0m[mds0[0m[0m[0m [0m[1;34mof[22m[0m[0m [0m[mwild0[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m
+                                   [0m[m(,)[0m[0m [0m[mbs[0m[0m [0m[mcs[0m[0m [0m[31m[31m→[31m[0m[0m [0m[0m[mbs[0m[0m[0m[0m[31m)[0m[0m
+                                [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[ma0[0m[0m[0m
+                                     [0m[31m([0m[0m[0m[0m[mworker[0m[0m[0m [0m[31m([0m[0m[0m[1;34mcase[22m[0m[0m [0m[0m[mds0[0m[0m[0m [0m[1;34mof[22m[0m[0m [0m[mwild0[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m
+                                                [0m[m(,)[0m[0m [0m[mbs[0m[0m [0m[mcs[0m[0m [0m[31m[31m→[31m[0m[0m [0m[0m[mcs[0m[0m[0m[0m[31m)[0m[0m
+                                             [0m[0m[mx[0m[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m
+      [0m[1;34min[22m[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[mx[0m[0m [0m[31m[31m→[31m[0m[0m [0m[0m[mworker[0m[0m[0m [0m[0m[mx[0m[0m[0m [0m[31m([0m[0m[0m[m[][0m[0m [0m[0m[32ma[0m[0m[0m[0m[31m)[0m[0m
+    [0m[mabsR[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[31m.[0m[0m [0m[31m([0m[0m[0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32mH[0m[0m [0m[0m[32ma[0m[0m[0m[0m[31m)[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m
+    [0m[mabsR[0m[0m [0m[31m=[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[32ma[0m[0m [0m[meta[0m[0m [0m[31m[31m→[31m[0m[0m [0m[31m([0m[0m[0m[31m[31mλ[31m[0m[0m [0m[mg[0m[0m [0m[31m[31m→[31m[0m[0m [0m[31m([0m[0m[0m[m.[0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[32mH[0m[0m [0m[0m[32ma[0m[0m[0m[0m[31m)[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[31m([0m[0m[0m[mabsH[0m[0m [0m[0m[32ma[0m[0m[0m[0m[31m)[0m[0m [0m[0m[mg[0m[0m[0m[0m[31m)[0m[0m [0m[0m[meta[0m[0m[0m
+    [0m[mrepR[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[31m.[0m[0m [0m[31m([0m[0m[0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m[0m[31m)[0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32mH[0m[0m [0m[0m[32ma[0m[0m[0m
+    [0m[mrepR[0m[0m [0m[31m=[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[32ma[0m[0m [0m[meta[0m[0m [0m[31m[31m→[31m[0m[0m [0m[31m([0m[0m[0m[31m[31mλ[31m[0m[0m [0m[mf[0m[0m [0m[31m[31m→[31m[0m[0m [0m[31m([0m[0m[0m[m.[0m[0m[0m[31m)[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[31m([0m[0m[0m[32mH[0m[0m [0m[0m[32ma[0m[0m[0m[0m[31m)[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[31m([0m[0m[0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m[0m[31m)[0m[0m [0m[0m[mf[0m[0m[0m[0m[31m)[0m[0m [0m[0m[meta[0m[0m[0m
+    [0m[m$dShow[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32mShow[0m[0m [0m[32m[[0m[0m[0m[32mInteger[0m[0m[0m[32m][0m[0m
+    [0m[m$dShow[0m[0m [0m[31m=[0m[0m [0m[m$fShow[][0m[0m [0m[32mInteger[0m[0m [0m[m$fShowInteger[0m[0m
+    [0m[mmain[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32mIO[0m[0m [0m[32m([0m[0m[0m[32m)[0m[0m
+    [0m[mmain[0m[0m [0m[31m=[0m[0m
+      [0m[mprint[0m[0m [0m[32m[[0m[0m[0m[32mInteger[0m[0m[0m[32m][0m[0m [0m[0m[m$dShow[0m[0m[0m
+            [0m[31m([0m[0m[0m[0m[mqsort[0m[0m[0m [0m[32mInteger[0m[0m [0m[m$fOrdInteger[0m[0m
+                   [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[32mInteger[0m[0m [0m8[0m
+                        [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[32mInteger[0m[0m [0m3[0m
+                             [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[32mInteger[0m[0m [0m5[0m
+                                  [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[32mInteger[0m[0m [0m7[0m
+                                       [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[32mInteger[0m[0m [0m2[0m
+                                            [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[32mInteger[0m[0m [0m9[0m
+                                                 [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[32mInteger[0m[0m [0m4[0m
+                                                      [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[32mInteger[0m[0m [0m6[0m
+                                                           [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[32mInteger[0m[0m [0m3[0m
+                                                                [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[32mInteger[0m[0m [0m2[0m
+                                                                     [0m[31m([0m[0m[0m[m[][0m[0m [0m[32mInteger[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m
+    [0m[mmain[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32mIO[0m[0m [0m[32m([0m[0m[0m[32m)[0m[0m
+    [0m[mmain[0m[0m [0m[31m=[0m[0m [0m[mrunMainIO[0m[0m [0m[32m([0m[0m[0m[32m)[0m[0m [0m[0m[mmain[0m[0m[0m[0m
+qsort-fusion (Built In)
+  [0m[7;93mrepR[27m[0m[0m [0m[32ma[0m[0m [0m[31m([0m[0m[0m[7;93mabsR[27m[0m[0m [0m[32ma[0m[0m [0m[31m([0m[0m[0m[mfix[0m[0m [0m[31m([0m[0m[0m[32m[[0m[0m[0m[32ma[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32mH[0m[0m [0m[32ma[0m[0m[0m[31m)[0m[0m [0m[7;93mg[27m[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[mfix[0m[0m [0m[31m([0m[0m[0m[32m[[0m[0m[0m[32ma[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32mH[0m[0m [0m[32ma[0m[0m[0m[31m)[0m[0m [0m[7;93mg[27m[0m[0m
+repH (:) (Assumed)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[mx[0m[0m [0m[mxs[0m[0m[0m[31m.[0m[0m
+  [0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mx[0m[0m[0m [0m[0m[mxs[0m[0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[31m([0m[0m[0m[m.[0m[0m[0m[31m)[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mx[0m[0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mxs[0m[0m[0m[0m[31m)[0m[0m
+repH ++ (Assumed)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[mxs[0m[0m [0m[mys[0m[0m[0m[31m.[0m[0m
+  [0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[31m([0m[0m[0m[m++[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mxs[0m[0m[0m [0m[0m[mys[0m[0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[31m([0m[0m[0m[m.[0m[0m[0m[31m)[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[31m([0m[0m[0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mxs[0m[0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mys[0m[0m[0m[0m[31m)[0m[0m
+repH [] (Assumed)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m[0m[31m.[0m[0m [0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[m[][0m[0m [0m[0m[32ma[0m[0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[mid[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m
+repH-absH-fusion (Assumed)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[mh[0m[0m[0m[31m.[0m[0m [0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[mabsH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mh[0m[0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[0m[mh[0m[0m[0m
+repHstrict (Assumed)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m[0m[31m.[0m[0m [0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[mundefined[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[mundefined[0m[0m [0m[31m([0m[0m[0m[32mH[0m[0m [0m[0m[32ma[0m[0m[0m[0m[31m)[0m[0m[0m
+Warning: Lemma repH (:) was assumed but not proven.
+repH (:)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[mx[0m[0m [0m[mxs[0m[0m[0m[31m.[0m[0m
+  [0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mx[0m[0m[0m [0m[0m[mxs[0m[0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[31m([0m[0m[0m[m.[0m[0m[0m[31m)[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mx[0m[0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mxs[0m[0m[0m[0m[31m)[0m[0m[0m
+Warning: Lemma repH ++ was assumed but not proven.
+repH ++
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[mxs[0m[0m [0m[mys[0m[0m[0m[31m.[0m[0m
+  [0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[31m([0m[0m[0m[m++[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mxs[0m[0m[0m [0m[0m[mys[0m[0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[31m([0m[0m[0m[m.[0m[0m[0m[31m)[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[31m([0m[0m[0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mxs[0m[0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mys[0m[0m[0m[0m[31m)[0m[0m[0m
+Warning: Lemma repH [] was assumed but not proven.
+repH []
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m[0m[31m.[0m[0m [0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[m[][0m[0m [0m[0m[32ma[0m[0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[mid[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m[0m
+Warning: Lemma repH-absH-fusion was assumed but not proven.
+repH-absH-fusion
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[mh[0m[0m[0m[31m.[0m[0m [0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[mabsH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mh[0m[0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[0m[mh[0m[0m[0m[0m
+Warning: Lemma repHstrict was assumed but not proven.
+repHstrict
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m[0m[31m.[0m[0m [0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[mundefined[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[mundefined[0m[0m [0m[31m([0m[0m[0m[32mH[0m[0m [0m[0m[32ma[0m[0m[0m[0m[31m)[0m[0m[0m

--- a/tests/golden-ghc-7.11/reverse_Reverse_hs_Reverse_hss.ref
+++ b/tests/golden-ghc-7.11/reverse_Reverse_hs_Reverse_hss.ref
@@ -1,0 +1,51 @@
+===================== Welcome to HERMIT ======================
+HERMIT is a toolkit for the interactive transformation of GHC
+core language programs. Documentation on HERMIT can be found
+on the HERMIT web page at:
+http://www.ittc.ku.edu/csdl/fpg/software/hermit.html
+
+You have just loaded the interactive shell. To exit, type 
+"abort" or "resume" to abort or resume GHC compilation.
+
+Type "help" for instructions on how to list or search the
+available HERMIT commands.
+
+To get started, you could try the following:
+  - type "binding-of 'foo", where "foo" is a function
+    defined in the module;
+  - type "set-pp-type Show" to display full type information;
+  - type "info" for more information about the current node;
+  - to descend into a child node, type the name of the child
+    ("info" includes a list of children of the current node);
+  - to ascend, use the "up" command;
+  - type "log" to display an activity log.
+==============================================================
+
+[0m[1;34mrec[22m[0m[0m [0m[mrev[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[31m.[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m
+    [0m[mrev[0m[0m [0m[31m=[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[32ma[0m[0m [0m[31m[31m→[31m[0m[0m
+      [0m[1;34mlet[22m[0m[0m [0m[1;34mrec[22m[0m[0m [0m[mwork[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m
+              [0m[mwork[0m[0m [0m[31m=[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[mys[0m[0m [0m[macc[0m[0m [0m[31m[31m→[31m[0m[0m
+                [0m[1;34mcase[22m[0m[0m [0m[0m[mys[0m[0m[0m [0m[1;34mof[22m[0m[0m [0m[mwild[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m
+                  [0m[m[][0m[0m [0m[31m[31m→[31m[0m[0m [0m[0m[macc[0m[0m[0m
+                  [0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[mx[0m[0m [0m[mxs[0m[0m [0m[31m[31m→[31m[0m[0m [0m[0m[mwork[0m[0m[0m [0m[0m[mxs[0m[0m[0m [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mx[0m[0m[0m [0m[0m[macc[0m[0m[0m[0m[31m)[0m[0m
+      [0m[1;34min[22m[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[mx0[0m[0m [0m[31m[31m→[31m[0m[0m [0m[0m[mwork[0m[0m[0m [0m[0m[mx0[0m[0m[0m [0m[31m([0m[0m[0m[m[][0m[0m [0m[0m[32ma[0m[0m[0m[0m[31m)[0m[0m
+[0m[mmain[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32mIO[0m[0m [0m[32m([0m[0m[0m[32m)[0m[0m
+[0m[mmain[0m[0m [0m[31m=[0m[0m
+  [0m[31m([0m[0m[0m[m$[0m[0m[0m[31m)[0m[0m [0m[32m[[0m[0m[0m[32mChar[0m[0m[0m[32m][0m[0m [0m[31m([0m[0m[0m[32mIO[0m[0m [0m[32m([0m[0m[0m[32m)[0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[mprint[0m[0m [0m[32m[[0m[0m[0m[32mChar[0m[0m[0m[32m][0m[0m [0m[31m([0m[0m[0m[m$fShow[][0m[0m [0m[32mChar[0m[0m [0m[m$fShowChar[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m
+      [0m[31m([0m[0m[0m[0m[mrev[0m[0m[0m [0m[32mChar[0m[0m [0m[31m([0m[0m[0m[munpackCString#[0m[0m [0m"hello"#[0m[0m[31m)[0m[0m[0m[31m)[0m[0m
+[0m[mmain[0m[0m [0m[32m[32m∷[32m[0m[0m [0m[32mIO[0m[0m [0m[32m([0m[0m[0m[32m)[0m[0m
+[0m[mmain[0m[0m [0m[31m=[0m[0m [0m[mrunMainIO[0m[0m [0m[32m([0m[0m[0m[32m)[0m[0m [0m[0m[mmain[0m[0m[0m[0m
+++ [] (Not Proven)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[mxs[0m[0m[0m[31m.[0m[0m [0m[31m([0m[0m[0m[m++[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mxs[0m[0m[0m [0m[31m([0m[0m[0m[m[][0m[0m [0m[0m[32ma[0m[0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[0m[mxs[0m[0m[0m
+++ strict (Not Proven)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m[0m[31m.[0m[0m [0m[31m([0m[0m[0m[m++[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[mundefined[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[mundefined[0m[0m [0m[31m([0m[0m[0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[32m→[32m[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m[0m[31m)[0m[0m
+recursive-definition-of-work-for-use-by-ww-fusion (Proven)
+  [0m[7;93mwork[27m[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[31m[31mλ[31m[0m[0m [0m[mx1[0m[0m [0m[31m[31m→[31m[0m[0m [0m[mrepH[0m[0m [0m[32ma[0m[0m [0m[31m([0m[0m[0m[7;93mf[27m[0m[0m [0m[31m([0m[0m[0m[31m[31mλ[31m[0m[0m [0m[mx2[0m[0m [0m[31m[31m→[31m[0m[0m [0m[mabsH[0m[0m [0m[32ma[0m[0m [0m[31m([0m[0m[0m[7;93mwork[27m[0m[0m [0m[0m[mx2[0m[0m[0m[0m[31m)[0m[0m[0m[31m)[0m[0m [0m[0m[mx1[0m[0m[0m[0m[31m)[0m[0m
+repH (:) (Not Proven)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[mx[0m[0m [0m[mxs[0m[0m[0m[31m.[0m[0m
+  [0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mx[0m[0m[0m [0m[0m[mxs[0m[0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[31m([0m[0m[0m[m.[0m[0m[0m[31m)[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[31m([0m[0m[0m[31m([0m[0m[0m[m:[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mx[0m[0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mxs[0m[0m[0m[0m[31m)[0m[0m
+repH ++ (Not Proven)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m [0m[mxs[0m[0m [0m[mys[0m[0m[0m[31m.[0m[0m
+  [0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[31m([0m[0m[0m[m++[0m[0m[0m[31m)[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mxs[0m[0m[0m [0m[0m[mys[0m[0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[31m([0m[0m[0m[m.[0m[0m[0m[31m)[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m [0m[31m([0m[0m[0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mxs[0m[0m[0m[0m[31m)[0m[0m [0m[31m([0m[0m[0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[0m[mys[0m[0m[0m[0m[31m)[0m[0m
+repH [] (Not Proven)
+  [0m[31m[31m∀[31m[0m[0m [0m[32ma[0m[0m[0m[31m.[0m[0m [0m[mrepH[0m[0m [0m[0m[32ma[0m[0m[0m [0m[31m([0m[0m[0m[m[][0m[0m [0m[0m[32ma[0m[0m[0m[0m[31m)[0m[0m [0m[31m[31m≡[31m[0m[0m [0m[mid[0m[0m [0m[32m[[0m[0m[0m[0m[32ma[0m[0m[0m[0m[32m][0m[0m[0m


### PR DESCRIPTION
There were more changes in HEAD than I was expecting, but I think I have this more or less right. I would like to find a way for the CPP conditionals to look nicer though.

It looks like the tests don't pass on HEAD because HEAD seems to `show` certain things differently (`I# 1` becomes `I# 1#`). The thing that worries me the most is that occasionally I'll see an escape code printed literally in the HEAD version (in particular, `[0m`).