### PR TITLE
Handle UnivCo

### DIFF
--- a/src/HERMIT/Core.hs
+++ b/src/HERMIT/Core.hs
@@ -473,6 +473,7 @@ data Crumb =
            | NthCo_Int | NthCo_Co
            | InstCo_Co | InstCo_Type
            | LRCo_LR | LRCo_Co
+           | UnivCo_Dom | UnivCo_Ran
            -- Quantified
            | Forall_Body
            | Conj_Lhs | Conj_Rhs
@@ -531,6 +532,8 @@ showCrumb = \case
                InstCo_Co         -> "inst-co"
                InstCo_Type       -> "inst-type"
                LRCo_Co           -> "lr-co"
+               UnivCo_Dom        -> "univ-dom"
+               UnivCo_Ran        -> "univ-ran"
                -- Quantified
                Forall_Body -> "forall-body"
                Conj_Lhs    -> "conj-lhs"

--- a/src/HERMIT/Dictionary/Navigation/Crumbs.hs
+++ b/src/HERMIT/Dictionary/Navigation/Crumbs.hs
@@ -95,6 +95,10 @@ crumbExternals = map (.+ Navigation)
         [ "Descend into the type within a coercion instantiation." ]
     , external "lr-co" LRCo_Co
         [ "Descend into the coercion within a left/right projection coercion." ]
+    , external "univ-dom" UnivCo_Dom
+        [ "Descend into the domain type within a universal coercion." ]
+    , external "univ-ran" UnivCo_Ran
+        [ "Descend into the range type within a universal coercion." ]
     , external "forall-body" Forall_Body
         [ "Descend into the body of a quantified clause." ]
     , external "conj-lhs" Conj_Lhs

--- a/src/HERMIT/PrettyPrinter/AST.hs
+++ b/src/HERMIT/PrettyPrinter/AST.hs
@@ -122,7 +122,8 @@ ppCoercion =  coVarCoT (ppVar >>^ \ v -> coText "CoVarCo" <+> v)
            <+ axiomInstCoT ppSDoc ppSDoc (const ppCoercion) (\ ax idx coes -> coText "AxiomInstCo" <+> ax <+> idx $$ nest 2 (vlist $ map parens coes))
            <+ lrCoT ppSDoc ppCoercion (\ lr co -> coText "LRCo" <+> lr $$ nest 2 (parens co))
            <+ tyConAppCoT ppSDoc (const ppCoercion) (\ r con coes -> coText "TyConAppCo" <+> coText (showRole r) <+> con $$ nest 2 (vlist $ map parens coes))
-           -- TODO: add UnivCo
+           <+ univCoT ppKindOrType ppKindOrType (\ s r dom ran -> coText "UnivCo" <+> coText (show s) <+> coText (showRole r) $$ nest 2 (cat [parens dom, parens ran]))
+           -- Should there be a catch-all here?
 
 ppVar :: PrettyH Var
 ppVar = readerT $ \ v -> ppSDoc >>^ modCol v

--- a/src/HERMIT/PrettyPrinter/Clean.hs
+++ b/src/HERMIT/PrettyPrinter/Clean.hs
@@ -438,7 +438,11 @@ ppCoercionR =
                                      else retApps (coText (showRole r ++ ":") <> ptc) cs)
  <+ axiomInstCoT (coAxiomName ^>> ppName CoercionColor) ppSDoc (\ _ -> ppCoercionR >>> parenExpr) (\ ax idx coes -> RetExpr (coText "axiomInst" <+> ax <+> idx <+> sep coes))
  <+ lrCoT ppSDoc (ppCoercionR >>> parenExpr) (\ lr co -> RetExpr (coercionColor lr <+> co))
- -- TODO: UnivCo and SubCo
+ 
+ <+ univCoT (ppTypeModeR >>^ normalExpr) (ppTypeModeR >>^ normalExpr)
+            (\ s r dom ran -> RetExpr (coKeyword "univ" <+> coText (show s) <+> coText (showRole r) <+> dom <+> ran)) -- retApps?
+
+
  <+ constT (return . RetAtom $ text "Unsupported Coercion Constructor")
 
 ppCoKind :: PrettyH Coercion

--- a/src/HERMIT/PrettyPrinter/Clean.hs
+++ b/src/HERMIT/PrettyPrinter/Clean.hs
@@ -439,8 +439,8 @@ ppCoercionR =
  <+ axiomInstCoT (coAxiomName ^>> ppName CoercionColor) ppSDoc (\ _ -> ppCoercionR >>> parenExpr) (\ ax idx coes -> RetExpr (coText "axiomInst" <+> ax <+> idx <+> sep coes))
  <+ lrCoT ppSDoc (ppCoercionR >>> parenExpr) (\ lr co -> RetExpr (coercionColor lr <+> co))
  
- <+ univCoT (ppTypeModeR >>^ normalExpr) (ppTypeModeR >>^ normalExpr)
-            (\ s r dom ran -> RetExpr (coKeyword "univ" <+> coText (show s) <+> coText (showRole r) <+> dom <+> ran)) -- retApps?
+ <+ univCoT ppTypeModeR ppTypeModeR
+            (\ s r dom ran -> retApps (coKeyword "univ" <+> coText (show s) <+> coText (showRole r)) [dom,ran])
 
 
  <+ constT (return . RetAtom $ text "Unsupported Coercion Constructor")


### PR DESCRIPTION
Handle `UnivCo`: navigation, transformation, pretty-printing. I was in some unfamiliar territory, and I don't have any tests. Some questions:

* `ppCoercion` in `HERMIT.PrettyPrinter.AST`: should there be a catch-all here as in `ppCoercionR` from `HERMIT.PrettyPrinter.Clean`?
* I'm skipping `UnivCo` in `allR` in the `Walker c Coercion` instance in `HERMIT.Kure`. Is that what we want? I guess so, as with `Refl`.
* In `HERMIT.PrettyPrinter.Clean.ppCoercion`, for the `UnivCo` case, should I use `retApps`?