### PR TITLE
Add addHermitCoreRules method to the HasCoreRules class.

### DIFF
--- a/src/HERMIT/Context.hs
+++ b/src/HERMIT/Context.hs
@@ -231,13 +231,16 @@ lookupHermitBindingSite v depth c = do HB d bnd _ <- lookupHermitBinding v c
 
 -- | A class of contexts that store GHC rewrite rules.
 class HasCoreRules c where
-    hermitCoreRules :: c -> [CoreRule]
+    hermitCoreRules    :: c -> [CoreRule]
+    addHermitCoreRules :: [CoreRule] -> c -> c
 
 deriving instance Typeable HasCoreRules
 
 instance HasCoreRules [CoreRule] where
     hermitCoreRules :: [CoreRule] -> [CoreRule]
     hermitCoreRules = id
+    addHermitCoreRules :: [CoreRule] -> [CoreRule] -> [CoreRule]
+    addHermitCoreRules = (++)
 
 ------------------------------------------------------------------------
 
@@ -354,6 +357,8 @@ instance ReadBindings HermitC where
 instance HasCoreRules HermitC where
   hermitCoreRules :: HermitC -> [CoreRule]
   hermitCoreRules = hermitC_specRules
+  addHermitCoreRules :: [CoreRule] -> HermitC -> HermitC
+  addHermitCoreRules rules c = c { hermitC_specRules = rules ++ hermitC_specRules c }
 
 ------------------------------------------------------------------------
 

--- a/src/HERMIT/Dictionary/Local/Case.hs
+++ b/src/HERMIT/Dictionary/Local/Case.hs
@@ -116,10 +116,10 @@ externals =
         , "e ==> case expr of C1 vs -> e; C2 vs -> e"] .+ Deep .+ Strictness
     , external "case-split-inline" ((\nm -> findVarT (unOccurrenceName nm) >>= promoteExprR . caseSplitInlineR . varToCoreExpr) :: OccurrenceName -> RewriteH LCore)
         [ "Like case-split, but additionally inlines the matched constructor "
-        , "applications for all occurances of the named variable." ] .+ Deep .+ Strictness
+        , "applications for all occurrences of the named variable." ] .+ Deep .+ Strictness
     , external "case-split-inline" (parseCoreExprT >=> promoteExprR . caseSplitInlineR :: CoreString -> RewriteH LCore)
         [ "Like case-split, but additionally inlines the matched constructor "
-        , "applications for all occurances of the case binder." ] .+ Deep .+ Strictness
+        , "applications for all occurrences of the case binder." ] .+ Deep .+ Strictness
     , external "case-intro-seq" (promoteExprR . caseIntroSeqR . cmpString2Var :: String -> RewriteH LCore)
         [ "Force evaluation of a variable by introducing a case."
         , "case-intro-seq 'v is is equivalent to adding @(seq v)@ in the source code." ] .+ Shallow .+ Introduce .+ Strictness
@@ -436,7 +436,7 @@ matchingFreeIdT idPred = do
     is    -> fail ("provided name matches " ++ show (length is) ++ " free identifiers.")
 
 -- | Like caseSplit, but additionally inlines the constructor applications
--- for each occurance of the named variable.
+-- for each occurrence of the named variable.
 --
 -- > caseSplitInline idPred = caseSplit idPred >>> caseInlineAlternativeR
 caseSplitInlineR :: ( ExtendPath c Crumb, ReadPath c Crumb, AddBindings c

--- a/src/HERMIT/External.hs
+++ b/src/HERMIT/External.hs
@@ -61,7 +61,7 @@ import Data.Typeable.Internal (TypeRep(..))
 
 import HERMIT.Core
 import HERMIT.Context (LocalPathH)
-import HERMIT.GHC (funTc)
+import HERMIT.GHC (tcFun)
 import HERMIT.Kure
 import HERMIT.Lemma
 
@@ -266,7 +266,7 @@ splitFunTyArgs tr = case splitFunTyMaybe tr of
                                          in (a:as, r')
 
 splitFunTyMaybe :: TypeRep -> Maybe (TypeRep, TypeRep)
-splitFunTyMaybe (TypeRep _ tc _krs [a,r]) | tc == funTc = Just (a,r)
+splitFunTyMaybe (TypeRep _ tc _krs [a,r]) | tc == tcFun = Just (a,r)
 splitFunTyMaybe _ = Nothing
 
 -----------------------------------------------------------------

--- a/src/HERMIT/External.hs
+++ b/src/HERMIT/External.hs
@@ -57,10 +57,11 @@ module HERMIT.External
 import Data.Map hiding (map)
 import Data.Dynamic
 import Data.List
-import Data.Typeable.Internal (TypeRep(..), funTc)
+import Data.Typeable.Internal (TypeRep(..))
 
 import HERMIT.Core
 import HERMIT.Context (LocalPathH)
+import HERMIT.GHC (funTc)
 import HERMIT.Kure
 import HERMIT.Lemma
 

--- a/src/HERMIT/GHC.hs
+++ b/src/HERMIT/GHC.hs
@@ -70,7 +70,7 @@ module HERMIT.GHC
 #endif
     , module Unify
     , getHscEnvCoreM
-    , funTc
+    , tcFun
     ) where
 
 -- Imports from GHC.
@@ -128,8 +128,10 @@ import           TypeRep (Type(..), TyLit(..))
 import           TysPrim (alphaTyVars)
 import           Unify (tcUnifyTys, BindFlag(..))
 
-import Data.List (intercalate)
+import Data.Typeable (typeRep,typeRepTyCon)
 import qualified Data.Typeable.Internal
+import Data.Proxy (Proxy(..))
+import Data.List (intercalate)
 
 import HERMIT.GHC.Typechecker
 
@@ -405,9 +407,5 @@ injectDependency hsc_env guts mod_name = do
     dflags = hsc_dflags hsc_env
     doc = ptext (sLit "dependency injection requested by HERMIT")
 
-funTc :: Data.Typeable.Internal.TyCon
-#if __GLASGOW_HASKELL__ > 710 
-funTc = Data.Typeable.Internal.tcFun
-#else
-funTc = Data.Typeable.Internal.funTc
-#endif
+tcFun :: Data.Typeable.Internal.TyCon
+tcFun = typeRepTyCon (typeRep (Proxy :: Proxy (Int -> Int)))

--- a/src/HERMIT/GHC.hs
+++ b/src/HERMIT/GHC.hs
@@ -70,6 +70,7 @@ module HERMIT.GHC
 #endif
     , module Unify
     , getHscEnvCoreM
+    , funTc
     ) where
 
 -- Imports from GHC.
@@ -128,6 +129,7 @@ import           TysPrim (alphaTyVars)
 import           Unify (tcUnifyTys, BindFlag(..))
 
 import Data.List (intercalate)
+import qualified Data.Typeable.Internal
 
 import HERMIT.GHC.Typechecker
 
@@ -402,3 +404,10 @@ injectDependency hsc_env guts mod_name = do
   where
     dflags = hsc_dflags hsc_env
     doc = ptext (sLit "dependency injection requested by HERMIT")
+
+funTc :: Data.Typeable.Internal.TyCon
+#if __GLASGOW_HASKELL__ > 710 
+funTc = Data.Typeable.Internal.tcFun
+#else
+funTc = Data.Typeable.Internal.funTc
+#endif

--- a/src/HERMIT/GHC.hs
+++ b/src/HERMIT/GHC.hs
@@ -129,7 +129,7 @@ import           TysPrim (alphaTyVars)
 import           Unify (tcUnifyTys, BindFlag(..))
 
 import Data.Typeable (typeRep,typeRepTyCon)
-import qualified Data.Typeable.Internal
+import qualified Data.Typeable
 import Data.Proxy (Proxy(..))
 import Data.List (intercalate)
 
@@ -407,5 +407,5 @@ injectDependency hsc_env guts mod_name = do
     dflags = hsc_dflags hsc_env
     doc = ptext (sLit "dependency injection requested by HERMIT")
 
-tcFun :: Data.Typeable.Internal.TyCon
+tcFun :: Data.Typeable.TyCon
 tcFun = typeRepTyCon (typeRep (Proxy :: Proxy (Int -> Int)))


### PR DESCRIPTION
I needed to generate and add GHC rewrite rules, so I extended the `HasCoreRules` class 

```Haskell
-- | A class of contexts that store GHC rewrite rules.
class HasCoreRules c where
    hermitCoreRules    :: c -> [CoreRule]
    addHermitCoreRules :: [CoreRule] -> c -> c
```

Some alternatives:

*   Split into two classes, like `ReadBindings` and `AddBindings`. For consistency, I guess we'd want "`ReadCoreRules`" and "`AddCoreRules`", but that'd be a lot of change to client code.
*   Add only one rule at a time: `addHermitCoreRule :: CoreRule -> c -> c`.
    The `[CoreRule]` version is perhaps a little more efficient for multiple rules (compared with repeated single additions), while the `CoreRule` version is more efficient for a single rule. Or maybe not, given GHC's SpecConstr transformation.
*   Replace `addHermitCoreRules` with `setHermitCoreRules`, since we can build `addHermitCoreRules` from `hermitCoreRules` and `setHermitCoreRules`.

I'm happy to tweak and resubmit.
